### PR TITLE
DosageUnit Valuesets added

### DIFF
--- a/input/fsh/alias.fsh
+++ b/input/fsh/alias.fsh
@@ -1,2 +1,4 @@
 Alias: $cs-event-timing = http://hl7.org/fhir/event-timing
 Alias: $ucum = http://unitsofmeasure.org
+Alias: $edqm = http://standardterms.edqm.eu
+Alias: $kbv-dosiereinheit =  https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_BMP_DOSIEREINHEIT

--- a/input/fsh/de_dosage.fsh
+++ b/input/fsh/de_dosage.fsh
@@ -15,12 +15,12 @@ Description: "Gibt an, wie das Medikament vom Patienten eingenommen wird/wurde o
 
 * patientInstruction MS
 
-// Delete all Timing fields that are not used in this level
 * timing MS
 * timing only TimingDE_Zeipunkte
 
 * doseAndRate MS
   * doseQuantity MS
+  * doseQuantity from DosageDoseQuantityDEVS
 
 // Beschreibungen
 * id
@@ -60,7 +60,7 @@ Description: "Gibt an, wie das Medikament vom Patienten eingenommen wird/wurde o
 * text
   * ^short = "Freitext-Dosierungsanweisungen, z. B. '3x täglich 1 Tablette'"
   * ^definition = "Freitext-Dosierungsanweisungen, z. B. '3x täglich 1 Tablette'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"
-  * ^comment = "Die Freitextdosierung ist auch dann anzugeben, wenn die Dosierung strukturiert angegeben wurde. Ein Algorithmus und Beispielimplementierung kann im IG eingesehen werden."
+  * ^comment = "Die Freitextdosierung sollte nur angegeben werden, wenn aufgrund der Komplexität keine strukturierte Dosierung möglich ist, um widersprüchliche Anweisungen zu vermeiden."
 
   /*
   	
@@ -125,11 +125,6 @@ Additional information about administration or preparation of the medication sho
 * doseAndRate
   * ^short = "Menge des verabreichten Medikaments"
   * ^definition = "Die verabreichte Menge des Medikaments."
-  * ^comment = "tbd"
-
-* doseAndRate.id
-  * ^short = "Eindeutige ID für die Referenzierung zwischen Elementen"
-  * ^definition = "Eindeutige ID für das Element innerhalb einer Ressource (für interne Verweise). Dies kann jeder beliebige Zeichenfolgenwert sein, der keine Leerzeichen enthält."
   * ^comment = "tbd"
 
 * doseAndRate.extension

--- a/input/fsh/de_dosage_dgmp.fsh
+++ b/input/fsh/de_dosage_dgmp.fsh
@@ -19,10 +19,11 @@ Description: "Gibt an, wie das Medikament vom Patienten eingenommen wird/wurde o
 * patientInstruction //Patient or consumer oriented instructions
 
 * timing only TimingDE_dgmp_Zeipunkte
-* doseAndRate 0..1 MS // Nur eine Dosierung für eine Medikation erlauben
+* doseAndRate 0..1 // Nur eine Dosierung für eine Medikation erlauben
   * type 0..0 //TODO: Sollte das fixed auf "ordered" gesetzt werden oder auf 0..0 gesetzt sein? http://terminology.hl7.org/CodeSystem/dose-rate-type
   * dose[x] only SimpleQuantity
-  * doseQuantity MS
+  * doseQuantity
+  * doseQuantity from DosageDoseQuantityDGMPVS
   * rate[x] 0..0
 
 // Remove unused Fields

--- a/input/fsh/terminologies/DosageDoseQuantityDGMPVS.fsh
+++ b/input/fsh/terminologies/DosageDoseQuantityDGMPVS.fsh
@@ -1,0 +1,5 @@
+ValueSet: DosageDoseQuantityDGMPVS
+Id: DosageDoseQuantityDGMP
+Title: "Dosage Dose-Quantity ValueSet DGMP"
+Description: "Diese ValueSet enthält die erlaubten Konzepte für die Dosierungseinheit in der Dosiermenge DGMP."
+* include codes from system $kbv-dosiereinheit

--- a/input/fsh/terminologies/DosageDoseQuantityVS.fsh
+++ b/input/fsh/terminologies/DosageDoseQuantityVS.fsh
@@ -1,0 +1,7 @@
+ValueSet: DosageDoseQuantityDEVS
+Id: DosageDoseQuantity
+Title: "Dosage Dose-Quantity ValueSet"
+Description: "Diese ValueSet enthält Konzepte für die Dosierungseinheit in der Dosiermenge."
+* include codes from system $kbv-dosiereinheit
+* include codes from system $ucum
+* include codes from valueset UnitOfPresentation

--- a/input/fsh/terminologies/EDQMUnitOfPresentationVS.fsh
+++ b/input/fsh/terminologies/EDQMUnitOfPresentationVS.fsh
@@ -1,0 +1,175 @@
+
+// Quelle: https://build.fhir.org/ig/hl7-eu/unicom-ig/branches/master/ValueSet-pharmaceutical-doseform-vs.html
+ValueSet: UnitOfPresentation
+Id: unit-of-presentation
+Title: "EDQM Unit of Presentation"
+Description: "ValueSet Einheit der Darreichungsform gemäß EDQM, UOP, siehe https://standardterms.edqm.eu/#"
+* $edqm#15001000 "Actuation"
+* $edqm#15001000 ^designation[0].language = #de
+* $edqm#15001000 ^designation[=].value = "Betätigung (Sprühstoß)"
+* $edqm#15002000 "Ampoule"
+* $edqm#15002000 ^designation[0].language = #de
+* $edqm#15002000 ^designation[=].value = "Ampulle"
+* $edqm#15004000 "Applicator"
+* $edqm#15004000 ^designation[0].language = #de
+* $edqm#15004000 ^designation[=].value = "Applikator"
+* $edqm#15005000 "Bag"
+* $edqm#15005000 ^designation[0].language = #de
+* $edqm#15005000 ^designation[=].value = "Beutel"
+* $edqm#15006000 "Barrel"
+* $edqm#15006000 ^designation[0].language = #de
+* $edqm#15006000 ^designation[=].value = "Kanister"
+* $edqm#15007000 "Blister"
+* $edqm#15007000 ^designation[0].language = #de
+* $edqm#15007000 ^designation[=].value = "Blisterpackung"
+* $edqm#15008000 "Block"
+* $edqm#15008000 ^designation[0].language = #de
+* $edqm#15008000 ^designation[=].value = "Stein"
+* $edqm#15009000 "Bottle"
+* $edqm#15009000 ^designation[0].language = #de
+* $edqm#15009000 ^designation[=].value = "Flasche"
+* $edqm#15011000 "Cachet"
+* $edqm#15011000 ^designation[0].language = #de
+* $edqm#15011000 ^designation[=].value = "Oblatenkapsel"
+* $edqm#15012000 "Capsule"
+* $edqm#15012000 ^designation[0].language = #de
+* $edqm#15012000 ^designation[=].value = "Kapsel"
+* $edqm#15013000 "Cartridge"
+* $edqm#15013000 ^designation[0].language = #de
+* $edqm#15013000 ^designation[=].value = "Patrone"
+* $edqm#15015000 "Collar"
+* $edqm#15015000 ^designation[0].language = #de
+* $edqm#15015000 ^designation[=].value = "Halsband"
+* $edqm#15016000 "Container"
+* $edqm#15016000 ^designation[0].language = #de
+* $edqm#15016000 ^designation[=].value = "Behältnis"
+* $edqm#15017000 "Cup"
+* $edqm#15017000 ^designation[0].language = #de
+* $edqm#15017000 ^designation[=].value = "Messbecher"
+* $edqm#15018000 "Cylinder"
+* $edqm#15018000 ^designation[0].language = #de
+* $edqm#15018000 ^designation[=].value = "Behältnis"
+* $edqm#15019000 "Dart"
+* $edqm#15019000 ^designation[0].language = #de
+* $edqm#15019000 ^designation[=].value = "Pfeil"
+* $edqm#15021000 "Dressing"
+* $edqm#15021000 ^designation[0].language = #de
+* $edqm#15021000 ^designation[=].value = "Verband"
+* $edqm#15022000 "Drop"
+* $edqm#15022000 ^designation[0].language = #de
+* $edqm#15022000 ^designation[=].value = "Tropfen"
+* $edqm#15023000 "Film"
+* $edqm#15023000 ^designation[0].language = #de
+* $edqm#15023000 ^designation[=].value = "Film"
+* $edqm#15024000 "Chewing gum"
+* $edqm#15024000 ^designation[0].language = #de
+* $edqm#15024000 ^designation[=].value = "Kaugummi"
+* $edqm#15025000 "Implant"
+* $edqm#15025000 ^designation[0].language = #de
+* $edqm#15025000 ^designation[=].value = "Implantat"
+* $edqm#15026000 "Inhaler"
+* $edqm#15026000 ^designation[0].language = #de
+* $edqm#15026000 ^designation[=].value = "Inhalator"
+* $edqm#15027000 "Insert"
+* $edqm#15027000 ^designation[0].language = #de
+* $edqm#15027000 ^designation[=].value = "Insert"
+* $edqm#15028000 "Jar"
+* $edqm#15028000 ^designation[0].language = #de
+* $edqm#15028000 ^designation[=].value = "Weithalsgefäß"
+* $edqm#15029000 "Lozenge"
+* $edqm#15029000 ^designation[0].language = #de
+* $edqm#15029000 ^designation[=].value = "Lutschtablette"
+* $edqm#15030000 "Lyophilisate"
+* $edqm#15030000 ^designation[0].language = #de
+* $edqm#15030000 ^designation[=].value = "Lyophilisat"
+* $edqm#15031000 "Matrix"
+* $edqm#15031000 ^designation[0].language = #de
+* $edqm#15031000 ^designation[=].value = "Matrix"
+* $edqm#15033000 "Pad"
+* $edqm#15033000 ^designation[0].language = #de
+* $edqm#15033000 ^designation[=].value = "Tampon"
+* $edqm#15034000 "Paper"
+* $edqm#15034000 ^designation[0].language = #de
+* $edqm#15034000 ^designation[=].value = "Papier"
+* $edqm#15035000 "Pastille"
+* $edqm#15035000 ^designation[0].language = #de
+* $edqm#15035000 ^designation[=].value = "Pastille"
+* $edqm#15036000 "Patch"
+* $edqm#15036000 ^designation[0].language = #de
+* $edqm#15036000 ^designation[=].value = "Pflaster"
+* $edqm#15037000 "Pen"
+* $edqm#15037000 ^designation[0].language = #de
+* $edqm#15037000 ^designation[=].value = "Pen"
+* $edqm#15038000 "Pendant"
+* $edqm#15038000 ^designation[0].language = #de
+* $edqm#15038000 ^designation[=].value = "Manschette"
+* $edqm#15039000 "Pessary"
+* $edqm#15039000 ^designation[0].language = #de
+* $edqm#15039000 ^designation[=].value = "Pessary"
+* $edqm#15040000 "Pillule"
+* $edqm#15040000 ^designation[0].language = #de
+* $edqm#15040000 ^designation[=].value = "Streukügelchen"
+* $edqm#15041000 "Pipette"
+* $edqm#15041000 ^designation[0].language = #de
+* $edqm#15041000 ^designation[=].value = "Pipette"
+* $edqm#15042000 "Plaster"
+* $edqm#15042000 ^designation[0].language = #de
+* $edqm#15042000 ^designation[=].value = "Pflaster"
+* $edqm#15043000 "Plug"
+* $edqm#15043000 ^designation[0].language = #de
+* $edqm#15043000 ^designation[=].value = "Einsatz"
+* $edqm#15044000 "Pouch"
+* $edqm#15044000 ^designation[0].language = #de
+* $edqm#15044000 ^designation[=].value = "Beutelchen"
+* $edqm#15045000 "Sachet"
+* $edqm#15045000 ^designation[0].language = #de
+* $edqm#15045000 ^designation[=].value = "Beutel"
+* $edqm#15046000 "Sponge"
+* $edqm#15046000 ^designation[0].language = #de
+* $edqm#15046000 ^designation[=].value = "Schwämmchen"
+* $edqm#15047000 "Spoonful"
+* $edqm#15047000 ^designation[0].language = #de
+* $edqm#15047000 ^designation[=].value = "ein Löffel voll"
+* $edqm#15048000 "Stick"
+* $edqm#15048000 ^designation[0].language = #de
+* $edqm#15048000 ^designation[=].value = "Stäbchen"
+* $edqm#15049000 "Straw"
+* $edqm#15049000 ^designation[0].language = #de
+* $edqm#15049000 ^designation[=].value = "Trinkhalm"
+* $edqm#15050000 "Strip"
+* $edqm#15050000 ^designation[0].language = #de
+* $edqm#15050000 ^designation[=].value = "Streifen"
+* $edqm#15051000 "Suppository"
+* $edqm#15051000 ^designation[0].language = #de
+* $edqm#15051000 ^designation[=].value = "Zäpfchen"
+* $edqm#15052000 "Syringe"
+* $edqm#15052000 ^designation[0].language = #de
+* $edqm#15052000 ^designation[=].value = "Spritze"
+* $edqm#15053000 "System"
+* $edqm#15053000 ^designation[0].language = #de
+* $edqm#15053000 ^designation[=].value = "System"
+* $edqm#15054000 "Tablet"
+* $edqm#15054000 ^designation[0].language = #de
+* $edqm#15054000 ^designation[=].value = "Tablette"
+* $edqm#15055000 "Tag"
+* $edqm#15055000 ^designation[0].language = #de
+* $edqm#15055000 ^designation[=].value = "Marke"
+* $edqm#15056000 "Tampon"
+* $edqm#15056000 ^designation[0].language = #de
+* $edqm#15056000 ^designation[=].value = "Tampon"
+* $edqm#15057000 "Thread"
+* $edqm#15057000 ^designation[0].language = #de
+* $edqm#15057000 ^designation[=].value = "Faden"
+* $edqm#15058000 "Tube"
+* $edqm#15058000 ^designation[0].language = #de
+* $edqm#15058000 ^designation[=].value = "Tube"
+* $edqm#15059000 "Vessel"
+* $edqm#15059000 ^designation[0].language = #de
+* $edqm#15059000 ^designation[=].value = "Behältnis"
+* $edqm#15060000 "Vial"
+* $edqm#15060000 ^designation[0].language = #de
+* $edqm#15060000 ^designation[=].value = "Durchstechflasche"
+* $edqm#15061000 "Puff"
+* $edqm#15062000 "Swab"
+* $edqm#15062000 ^designation[0].language = #de
+* $edqm#15062000 ^designation[=].value = "Tupfer"

--- a/input/fsh/timing_de.fsh
+++ b/input/fsh/timing_de.fsh
@@ -44,6 +44,11 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * ^definition = "Entweder eine Dauer für die Länge des Zeitplans, ein Bereich möglicher Längen oder äußere Begrenzungen für Start- und/oder Endgrenzen des Zeitplans."
   * ^comment = "tbd"
 
+* repeat.boundsDuration MS
+  * ^short = "Dauer der Dosieranweisung ausgedrückt in UCUM-Einheiten"
+  * ^definition = "Entweder eine Dauer für die Länge des Zeitplans, ein Bereich möglicher Längen oder äußere Begrenzungen für Start- und/oder Endgrenzen des Zeitplans."
+  * system = $ucum
+
 * repeat.count
   * ^short = "Anzahl der Wiederholungen"
   * ^definition = "Gesamtanzahl der gewünschten Wiederholungen über die gesamte Dauer des Zeitplans. Falls countMax vorhanden ist, gibt dieses Element die Untergrenze des zulässigen Bereichs der Wiederholungsanzahl an."

--- a/input/fsh/timing_de_dgmp.fsh
+++ b/input/fsh/timing_de_dgmp.fsh
@@ -11,7 +11,7 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * bounds[x] MS
   * bounds[x] only Duration
   * boundsDuration MS
-  * boundsDuration.system = $ucum (exactly)
+  * boundsDuration.system = $ucum
   * boundsDuration.code from De_Dosage_UCUM_UnitsOfTime_DgMP (required)
 
   * frequency MS

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,8 @@ publisher:
 # package id and the value is the version (or dev/current). For advanced
 # use cases, the value can be an object with keys for id, uri, and version.
 #
-# dependencies:
+dependencies:
+  kbv.all.st: 1.23.0
 #   hl7.fhir.us.mcode:
 #     id: mcode
 #     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode


### PR DESCRIPTION
This pull request introduces several updates to the FHIR Shorthand (FSH) files, focusing on terminology enhancements, dosage instructions, and dependency management. The changes include the addition of new aliases, modifications to dosage-related fields, creation of new ValueSets, and updates to timing and dependency configurations.

### Terminology Enhancements:
* Added new aliases `$edqm` and `$kbv-dosiereinheit` for standard terms and dosage units. (`input/fsh/alias.fsh`, [input/fsh/alias.fshR3-R4](diffhunk://#diff-b55af4fc880c083b4eafbc0ae97efaf64329cb5454775aca75a0de46fd9b90faR3-R4))
* Created `UnitOfPresentation` ValueSet to define units of pharmaceutical presentation based on EDQM terms. (`input/fsh/terminologies/EDQMUnitOfPresentationVS.fsh`, [input/fsh/terminologies/EDQMUnitOfPresentationVS.fshR1-R175](diffhunk://#diff-a8dea026abb188247b497544aea4032773ed12edb58185794aaf38b361ba1121R1-R175))

### Dosage Instructions Updates:
* Updated `doseQuantity` field to reference new ValueSets (`DosageDoseQuantityDEVS` and `DosageDoseQuantityDGMPVS`) for allowed concepts in dosage units. (`input/fsh/de_dosage.fsh`, [[1]](diffhunk://#diff-5137da83efc76904fc06e5b9fba91aab76682a858722260c099a7f43b8b9e66aL18-R23); `input/fsh/de_dosage_dgmp.fsh`, [[2]](diffhunk://#diff-b9135567593398a7f7405ccf16ca312a8d60e87a8754a774c1ca9921bfe710b5L22-R26)
* Revised `^comment` for `text` field to clarify when free-text dosage instructions should be used. (`input/fsh/de_dosage.fsh`, [input/fsh/de_dosage.fshL63-R63](diffhunk://#diff-5137da83efc76904fc06e5b9fba91aab76682a858722260c099a7f43b8b9e66aL63-R63))
* Removed unused `doseAndRate.id` field to streamline dosage-related definitions. (`input/fsh/de_dosage.fsh`, [input/fsh/de_dosage.fshL130-L134](diffhunk://#diff-5137da83efc76904fc06e5b9fba91aab76682a858722260c099a7f43b8b9e66aL130-L134))

### ValueSet Creation:
* Added `DosageDoseQuantityDEVS` and `DosageDoseQuantityDGMPVS` ValueSets to define allowed concepts for dosage units. (`input/fsh/terminologies/DosageDoseQuantityVS.fsh`, [[1]](diffhunk://#diff-c35c00b014d01947b7991c74b543a53e71699e623b9181a33cf77e674cf207c9R1-R7); `input/fsh/terminologies/DosageDoseQuantityDGMPVS.fsh`, [[2]](diffhunk://#diff-908152e7be957db97a92c878b09e9647d1e8d9b44befd2eeaa787db81d4faf0fR1-R5)

### Timing Configuration Updates:
* Added `repeat.boundsDuration` field with UCUM units to specify the duration of dosage instructions. (`input/fsh/timing_de.fsh`, [input/fsh/timing_de.fshR47-R51](diffhunk://#diff-901b48ee8dd4a56b3715202a34e0996e0b69cd1926ba3da484424a8c50545b7aR47-R51))
* Adjusted `boundsDuration.system` to remove the `exactly` constraint. (`input/fsh/timing_de_dgmp.fsh`, [input/fsh/timing_de_dgmp.fshL14-R14](diffhunk://#diff-335fc65bc7f42f16c027fa42021f65a1707e13997da9f9c738fc9b41944ef0d2L14-R14))

### Dependency Management:
* Added dependency `kbv.all.st` version `1.23.0` to the `sushi-config.yaml` file. (`sushi-config.yaml`, [sushi-config.yamlL27-R28](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L27-R28))