### PR TITLE
Refactor dosage and timing definitions for improved clarity and compliance with FHIR standards.

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,5 +1,5 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-de.medication.r4.json
+ig = fsh-generated/resources/ImplementationGuide-de.fhir.medication.json
 #template = https://github.com/gematik/fhir-ig-template
 template = #custom-template
 auto-load = true

--- a/input/fsh/datatypes/dosage_de.fsh
+++ b/input/fsh/datatypes/dosage_de.fsh
@@ -1,134 +1,25 @@
+// TODO: Infusion A direkt nach Infusion B geben soll laut FHIR Standard in .text. Hier müsste man noch eine Extension "PractitionerInstruction" definieren, 
+// um .text nur für FreitextDosierungen zu verwenden und nicht für strukturierte Dosierungen.
 Profile: DosageDE
 Parent: Dosage
 Id: DosageDE
 Title: "Dosage für deutschlandweite Nutzung"
 Description: "Gibt an, wie das Medikament vom Patienten eingenommen wird/wurde oder eingenommen werden soll."
-* obeys de-dosage-if-sequence-then-boundsDuration // Sequenzen müssen eine Dauer beinhalten
-
+* extension contains GeneratedDosageInstructions named generatedDosageInstructions 0..1 MS
 * text 0..1 MS
-  * extension contains GeneratedDosageInstructions named generatedDosageInstructions 0..1 MS
-
-* sequence MS
-
-* additionalInstruction MS
-  * text MS
-
-* patientInstruction MS
-
-* timing MS
-* timing only TimingDE
-
-* doseAndRate MS
-  * doseQuantity MS
-  * doseQuantity from DosageDoseQuantityDEVS
-
-// Beschreibungen
-* id
-  * ^short = "Eindeutige ID für die Referenzierung zwischen Elementen"
-  * ^definition = "Eindeutige ID für das Element innerhalb einer Ressource (für interne Verweise). Dies kann jeder beliebige Zeichenfolgenwert sein, der keine Leerzeichen enthält."
-  * ^comment = "tbd"
-
-* extension
-  * ^short = "Zusätzlicher Inhalt, der von Implementierungen definiert wird"
-  * ^definition = "Kann verwendet werden, um zusätzliche Informationen darzustellen, die nicht Teil der Basisdefinition des Elements sind. Um die Verwendung von Erweiterungen sicher und handhabbar zu machen, gibt es einen strikten Governance-Prozess für die Definition und Verwendung von Erweiterungen. Obwohl jeder Implementierer eine Erweiterung definieren kann, gibt es Anforderungen, die im Rahmen der Definition der Erweiterung erfüllt werden MÜSSEN."
-  * ^comment = "Es darf kein Stigma mit der Verwendung von Erweiterungen durch eine beliebige Anwendung, ein Projekt oder einen Standard verbunden sein - unabhängig von der Institution oder Gerichtsbarkeit, die die Erweiterungen verwendet oder definiert. Die Verwendung von Erweiterungen ermöglicht es der FHIR-Spezifikation, für alle einen einfachen Kern beizubehalten."
-
-* modifierExtension
-  * ^short = "Erweiterungen, die nicht ignoriert werden dürfen, selbst wenn sie nicht erkannt werden"
-  * ^definition = "Kann verwendet werden, um zusätzliche Informationen darzustellen, die nicht Teil der Basisdefinition des Elements sind und das Verständnis des Elements, in dem sie enthalten sind, und/oder das Verständnis der Nachkommen des enthaltenen Elements modifizieren. In der Regel bieten Modifizierer-Elemente Negationen oder Qualifikationen. Um die Verwendung von Erweiterungen sicher und handhabbar zu machen, gibt es einen strikten Governance-Prozess für die Definition und Verwendung von Erweiterungen. Obwohl jeder Implementierer eine Erweiterung definieren kann, gibt es Anforderungen, die im Rahmen der Definition der Erweiterung erfüllt werden MÜSSEN. Anwendungen, die eine Ressource verarbeiten, müssen auf Modifizierer-Erweiterungen prüfen. Modifizierer-Erweiterungen DÜRFEN NICHT die Bedeutung von Elementen auf Resource oder DomainResource ändern (einschließlich der Bedeutung von modifierExtension selbst)."
-  * ^comment = "Es darf kein Stigma mit der Verwendung von Erweiterungen durch eine beliebige Anwendung, ein Projekt oder einen Standard verbunden sein - unabhängig von der Institution oder Gerichtsbarkeit, die die Erweiterungen verwendet oder definiert. Die Verwendung von Erweiterungen ermöglicht es der FHIR-Spezifikation, für alle einen einfachen Kern beizubehalten."
-
-* sequence
-  * ^short = "Die Reihenfolge der Dosierungsanweisungen"
-  * ^definition = "Gibt die Reihenfolge an, in der die Dosierungsanweisungen angewendet oder interpretiert werden sollen."
-  * ^comment = "Wenn die Sequenz nicht angegeben wird, dann gilt für alle angegebenen Dosierungen implizit die Sequenz 0."
-
-* text
-  * ^short = "Freitext-Dosierungsanweisungen, z. B. '3x täglich 1 Tablette'"
-  * ^definition = "Freitext-Dosierungsanweisungen, z. B. '3x täglich 1 Tablette'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"
+  * ^short = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'"
+  * ^definition = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"
   * ^comment = "Die Freitextdosierung sollte nur angegeben werden, wenn aufgrund der Komplexität keine strukturierte Dosierung möglich ist, um widersprüchliche Anweisungen zu vermeiden."
-
-* additionalInstruction
-  * ^short = "Zusätzliche Anweisungen oder Warnhinweise für den Patienten - z. B. „zu den Mahlzeiten“, „kann Schläfrigkeit verursachen“"
-  * ^definition = "Zusätzliche Anweisungen für den Patienten zur Einnahme des Medikaments (z. B. „zu den Mahlzeiten“ oder „eine halbe bis eine Stunde vor dem Essen einnehmen“) oder Warnhinweise zum Medikament (z. B. „kann Schläfrigkeit verursachen“ oder „Hautkontakt mit direktem Sonnenlicht oder Sonnenlampen vermeiden“)."
-  * ^comment = "Informationen zur Verabreichung oder Zubereitung des Medikaments (z. B. „so schnell wie möglich über den intraperitonealen Port infundieren“ oder „unmittelbar nach Medikament X“) sollten in dosage.text angegeben werden."
-
-* patientInstruction
-  * ^short = "Patienten- oder verbraucherorientierte Anweisungen"
-  * ^definition = "Anweisungen in Begriffen, die vom Patienten oder Verbraucher verstanden werden."
-  * ^comment = "tbd"
-
-* timing
+* timing MS
   * ^short = "Wann das Medikament verabreicht werden soll"
   * ^definition = "Wann das Medikament verabreicht werden soll."
-  * ^comment = "Dieses Attribut muss nicht immer ausgefüllt sein, während Dosage.text in der Regel ausgefüllt wird. Wenn beide ausgefüllt sind, sollte Dosage.text den Inhalt von Dosage.timing widerspiegeln."
-
-* site
-  * ^short = "Körperstelle zur Verabreichung"
-  * ^definition = "Körperstelle, an der das Medikament verabreicht werden soll."
-  * ^comment = "Wenn der Anwendungsfall Attribute aus der BodySite-Ressource erfordert (z. B. zur Identifizierung und separaten Nachverfolgung), dann verwenden Sie die Standardextension Bodysite. Kann ein Übersichtscode sein oder ein Verweis auf eine sehr präzise Definition der Stelle oder beides."
-
-* route
-  * ^short = "Wie das Medikament in den Körper gelangen soll"
-  * ^definition = "Wie das Medikament in den Körper gelangen soll."
-  * ^comment = "tbd"
-
-* method
-  * ^short = "Technik zur Verabreichung des Medikaments"
-  * ^definition = "Technik zur Verabreichung des Medikaments."
-  * ^comment = "Terminologien präkoordinieren diesen Begriff häufig mit dem Verabreichungsweg und/oder der Darreichungsform."
-
-* doseAndRate
+  * ^comment = "Um widersprüchliche Anweisungen zu vermeiden, ist entweder Dosage.timing oder Dosage.text zu befüllen. Falls eine strukturierte Dosierung als Text abgebildet werden soll ist dafür die GeneratedDosageInstructions Extension zu verwenden."
+* timing only TimingDE
+* doseAndRate MS
   * ^short = "Menge des verabreichten Medikaments"
   * ^definition = "Die verabreichte Menge des Medikaments."
-  * ^comment = "tbd"
-
-* doseAndRate.extension
-  * ^short = "Zusätzlicher Inhalt, der von Implementierungen definiert wird"
-  * ^definition = "Kann verwendet werden, um zusätzliche Informationen darzustellen, die nicht Teil der Basisdefinition des Elements sind. Um die Verwendung von Erweiterungen sicher und handhabbar zu machen, gibt es einen strikten Governance-Prozess für die Definition und Verwendung von Erweiterungen. Obwohl jeder Implementierer eine Erweiterung definieren kann, gibt es Anforderungen, die im Rahmen der Definition der Erweiterung erfüllt werden MÜSSEN."
-  * ^comment = "Es darf kein Stigma mit der Verwendung von Erweiterungen durch eine beliebige Anwendung, ein Projekt oder einen Standard verbunden sein - unabhängig von der Institution oder Gerichtsbarkeit, die die Erweiterungen verwendet oder definiert. Die Verwendung von Erweiterungen ermöglicht es der FHIR-Spezifikation, für alle einen einfachen Kern beizubehalten."
-
-* doseAndRate.type
-  * ^short = "Art der angegebenen Dosis oder Rate"
-  * ^definition = "Die Art der angegebenen Dosis oder Rate, z. B. verordnet oder berechnet."
-  * ^comment = "tbd"
-
-* maxDosePerPeriod
-  * ^short = "Obergrenze für das Medikament pro Zeiteinheit"
-  * ^definition = "Obergrenze für das Medikament pro Zeiteinheit."
-  * ^comment = "Dies ist als Ergänzung zur Dosierung gedacht, wenn es eine Obergrenze gibt. Zum Beispiel „2 Tabletten alle 4 Stunden bis maximal 8/Tag“."
-
-* maxDosePerAdministration
-  * ^short = "Obergrenze für das Medikament pro Verabreichung"
-  * ^definition = "Obergrenze für das Medikament pro Verabreichung."
-  * ^comment = "Dies ist als Ergänzung zur Dosierung gedacht, wenn es eine Obergrenze gibt. Zum Beispiel eine dosisflächenbezogene Dosis mit einer Höchstmenge wie 1,5 mg/m2 (maximal 2 mg) i.v. über 5 - 10 Minuten hätte doseQuantity von 1,5 mg/m2 und maxDosePerAdministration von 2 mg."
-
-* maxDosePerLifetime
-  * ^short = "Obergrenze für das Medikament über die Lebenszeit des Patienten"
-  * ^definition = "Obergrenze für das Medikament über die Lebenszeit des Patienten."
-  * ^comment = "tbd"
-
-* doseAndRate.dose[x]
-  * ^short = "Menge des Medikaments pro Dosis"
-  * ^definition = "Menge des Medikaments pro Dosis."
-  * ^comment = "Beachten Sie, dass dies die Menge des angegebenen Medikaments angibt, nicht die Menge für die einzelnen Wirkstoffe. Jede Wirkstoffmenge kann in der Medication-Ressource kommuniziert werden. Zum Beispiel, wenn man angeben möchte, dass eine Tablette 375 mg enthält und die Dosis eine Tablette beträgt, kann man die Medication-Ressource verwenden, um zu dokumentieren, dass die Tablette aus 375 mg des Wirkstoffs XYZ besteht. Alternativ, wenn die Dosis 375 mg beträgt, muss man möglicherweise nur angeben, dass es sich um eine Tablette handelt. Bei einer Infusion wie Dopamin, bei der 400 mg Dopamin in 500 ml einer Infusionslösung gemischt werden, würde dies alles in der Medication-Ressource kommuniziert werden. Wenn die Verabreichung nicht als sofortig vorgesehen ist (Rate ist vorhanden oder Timing hat eine Dauer), kann dies angegeben werden, um die Gesamtmenge anzugeben, die über den im Zeitplan angegebenen Zeitraum verabreicht werden soll, z. B. 500 ml in der Dosis, wobei Timing verwendet wird, um anzugeben, dass dies über 4 Stunden erfolgen soll."
-
-* doseAndRate.rate[x]
-  * ^short = "Menge des Medikaments pro Zeiteinheit"
-  * ^definition = "Menge des Medikaments pro Zeiteinheit."
-  * ^comment = "Es ist möglich, sowohl eine Rate als auch eine Dosismenge anzugeben, um vollständige Details darüber zu liefern, wie das Medikament verabreicht und bereitgestellt werden soll. Wenn die Rate im Laufe der Zeit geändert werden soll, sollte jede Änderung je nach lokalen Regeln/Vorschriften als neue Version der MedicationRequest mit aktualisierter Rate erfasst werden oder mit einer neuen MedicationAdministration. Es ist möglich, eine Rate über die Zeit anzugeben (z. B. 100 ml/Stunde) entweder mit rateRatio oder rateQuantity. Die rateQuantity-Variante erfordert, dass Systeme die UCUM-Grammatik parsen können, bei der ml/Stunde enthalten ist, anstatt eines spezifischen Verhältnisses, bei dem die Zeit als Nenner angegeben ist. Wenn eine Rate wie 500 ml über 2 Stunden angegeben wird, ist die Verwendung von rateRatio semantisch möglicherweise korrekter als die Angabe mit rateQuantity von 250 mg/Stunde."
-
-* asNeeded[x]
-  * ^short = "Nach Bedarf einnehmen (für x)"
-  * ^definition = "Gibt an, ob das Medikament nur bei Bedarf innerhalb eines bestimmten Dosierungsplans eingenommen wird (Boolean-Option), oder gibt die Voraussetzung für die Einnahme des Medikaments an (CodeableConcept)."
-  * ^comment = "Kann „nach Bedarf“ ohne Grund ausdrücken, indem der Boolean auf True gesetzt wird. In diesem Fall wird das CodeableConcept nicht ausgefüllt. Oder man kann „nach Bedarf“ mit Grund angeben, indem das CodeableConcept ausgefüllt wird. In diesem Fall wird angenommen, dass der Boolean auf True gesetzt ist. Wenn der Boolean auf False gesetzt wird, wird die Dosis nach Plan verabreicht und ist nicht „prn“ oder „nach Bedarf“."
-
-
-
-// Invarianten
-// TODO
-Invariant: de-dosage-if-sequence-then-boundsDuration
-Description: "If a sequence is given the duration must be stated"
-Expression: "sequence.exists() implies timing.repeat.bounds.exists()"
-Severity: #error
-
+  * doseQuantity MS
+    * ^short = "Menge des Medikaments pro Dosis"
+    * ^definition = "Menge des Medikaments pro Dosis."
+    * ^comment = "Beachten Sie, dass dies die Menge des angegebenen Medikaments angibt, nicht die Menge für die einzelnen Wirkstoffe. Jede Wirkstoffmenge kann in der Medication-Ressource kommuniziert werden. Zum Beispiel, wenn man angeben möchte, dass eine Tablette 375 mg enthält und die Dosis eine Tablette beträgt, kann man die Medication-Ressource verwenden, um zu dokumentieren, dass die Tablette aus 375 mg des Wirkstoffs XYZ besteht. Alternativ, wenn die Dosis 375 mg beträgt, muss man möglicherweise nur angeben, dass es sich um eine Tablette handelt. Bei einer Infusion wie Dopamin, bei der 400 mg Dopamin in 500 ml einer Infusionslösung gemischt werden, würde dies alles in der Medication-Ressource kommuniziert werden. Wenn die Verabreichung nicht als sofortig vorgesehen ist (Rate ist vorhanden oder Timing hat eine Dauer), kann dies angegeben werden, um die Gesamtmenge anzugeben, die über den im Zeitplan angegebenen Zeitraum verabreicht werden soll, z. B. 500 ml in der Dosis, wobei Timing verwendet wird, um anzugeben, dass dies über 4 Stunden erfolgen soll."
+  * doseQuantity from DosageDoseQuantityDEVS

--- a/input/fsh/datatypes/dosage_dgmp.fsh
+++ b/input/fsh/datatypes/dosage_dgmp.fsh
@@ -3,23 +3,16 @@ Parent: DosageDE
 Id: DosageDgMP
 Title: "Dosage für dgMP"
 Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenommen wird/wurde oder eingenommen werden soll."
-
 * obeys DosageStructuredOrFreeText
-* text // Free text dosage instructions e.g. SIG
-  * extension[generatedDosageInstructions]
-    * extension[algorithm]
-      * valueCoding 1..1 MS // The algorithm used to generate the text
-        * ^patternCoding.system = Canonical(DosageTextAlgorithmsCS)
-        * ^patternCoding.code = #GermanDosageTextGenerator
-        * version 1..1 MS
-
-* additionalInstruction 0..0
-
-* patientInstruction //Patient or consumer oriented instructions
-
+* extension[generatedDosageInstructions]
+  * extension[algorithm]
+    * valueCoding 1..1 MS // The algorithm used to generate the text
+      * ^patternCoding.system = Canonical(DosageTextAlgorithmsCS)
+      * ^patternCoding.code = #GermanDosageTextGenerator
+      * version 1..1 MS
 * timing only TimingDgMP
 * doseAndRate 0..1 // Nur eine Dosierung für eine Medikation erlauben
-  * type 0..0 //TODO: Sollte das fixed auf "ordered" gesetzt werden oder auf 0..0 gesetzt sein? http://terminology.hl7.org/CodeSystem/dose-rate-type
+  * type 0..0
   * dose[x] only SimpleQuantity
   * doseQuantity
   * doseQuantity from $kbv-dosiereinheit-vs
@@ -27,6 +20,8 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
 
 // Remove unused Fields
 * sequence 0..0
+* additionalInstruction 0..0
+* patientInstruction 0..0
 * asNeeded[x] 0..0
 * site 0..0
 * route 0..0
@@ -38,7 +33,7 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
 Invariant: DosageStructuredOrFreeText
 Description: "Dosage must be either structured or free text, but not both at the same time."
 Expression: "
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
   text.exists() and timing.empty() and doseAndRate.empty()) or (text.empty() and timing.exists() and doseAndRate.exists()
 )
 "

--- a/input/fsh/datatypes/timing_de.fsh
+++ b/input/fsh/datatypes/timing_de.fsh
@@ -3,123 +3,37 @@ Parent: Timing
 Id: TimingDE
 Title: "Zeitmuster für deutschlandweite Dosierungen"
 Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne werden verwendet, um festzuhalten, wann etwas geplant, erwartet oder angefordert ist. Die häufigste Anwendung ist in Dosierungsanweisungen für Medikamente. Sie werden aber auch für die Planung verschiedener Versorgungsleistungen genutzt und können zur Dokumentation von bereits erfolgten oder laufenden Aktivitäten verwendet werden."
-// Beschreibungen
-* id
-  * ^short = "Eindeutige ID zur Referenzierung zwischen Elementen"
-  * ^definition = "Eindeutige ID für das Element innerhalb einer Ressource (für interne Verweise). Dies kann jeder beliebige Zeichenfolgenwert sein, der keine Leerzeichen enthält."
-  * ^comment = "tbd"
-
-* extension
-  * ^short = "Zusätzlicher Inhalt, der von Implementierungen definiert wird"
-  * ^definition = "Kann verwendet werden, um zusätzliche Informationen darzustellen, die nicht Teil der Basisdefinition des Elements sind. Um die Verwendung von Erweiterungen sicher und handhabbar zu machen, gibt es einen strikten Governance-Prozess für die Definition und Verwendung von Erweiterungen. Obwohl jeder Implementierer eine Erweiterung definieren kann, gibt es Anforderungen, die im Rahmen der Definition der Erweiterung erfüllt werden MÜSSEN."
-  * ^comment = "Es darf kein Stigma mit der Verwendung von Erweiterungen durch eine beliebige Anwendung, ein Projekt oder einen Standard verbunden sein - unabhängig von der Institution oder Gerichtsbarkeit, die die Erweiterungen verwendet oder definiert. Die Verwendung von Erweiterungen ermöglicht es der FHIR-Spezifikation, für alle einen einfachen Kern beizubehalten."
-
-* modifierExtension
-  * ^short = "Erweiterungen, die nicht ignoriert werden dürfen, selbst wenn sie nicht erkannt werden"
-  * ^definition = "Kann verwendet werden, um zusätzliche Informationen darzustellen, die nicht Teil der Basisdefinition des Elements sind und das Verständnis des Elements, in dem sie enthalten sind, und/oder das Verständnis der Nachkommen des enthaltenen Elements modifizieren. In der Regel bieten Modifizierer-Elemente Negationen oder Qualifikationen. Um die Verwendung von Erweiterungen sicher und handhabbar zu machen, gibt es einen strikten Governance-Prozess für die Definition und Verwendung von Erweiterungen. Obwohl jeder Implementierer eine Erweiterung definieren kann, gibt es Anforderungen, die im Rahmen der Definition der Erweiterung erfüllt werden MÜSSEN. Anwendungen, die eine Ressource verarbeiten, müssen auf Modifizierer-Erweiterungen prüfen. Modifizierer-Erweiterungen DÜRFEN NICHT die Bedeutung von Elementen auf Resource oder DomainResource ändern (einschließlich der Bedeutung von modifierExtension selbst)."
-  * ^comment = "Es darf kein Stigma mit der Verwendung von Erweiterungen durch eine beliebige Anwendung, ein Projekt oder einen Standard verbunden sein - unabhängig von der Institution oder Gerichtsbarkeit, die die Erweiterungen verwendet oder definiert. Die Verwendung von Erweiterungen ermöglicht es der FHIR-Spezifikation, für alle einen einfachen Kern beizubehalten."
-
-* event
-  * ^short = "Wann das Ereignis eintritt"
-  * ^definition = "Gibt bestimmte Zeitpunkte an, zu denen das Ereignis eintritt."
-  * ^comment = "tbd"
-
-* repeat
+* repeat MS
   * ^short = "Wann das Ereignis stattfinden soll"
   * ^definition = "Eine Menge von Regeln, die beschreiben, wann das Ereignis geplant ist."
-  * ^comment = "tbd"
-
-* repeat.id
-  * ^short = "Eindeutige ID zur Referenzierung zwischen Elementen"
-  * ^definition = "Eindeutige ID für das Element innerhalb einer Ressource (für interne Verweise). Dies kann jeder beliebige Zeichenfolgenwert sein, der keine Leerzeichen enthält."
-  * ^comment = "tbd"
-
-* repeat.extension
-  * ^short = "Zusätzlicher Inhalt, der von Implementierungen definiert wird"
-  * ^definition = "Kann verwendet werden, um zusätzliche Informationen darzustellen, die nicht Teil der Basisdefinition des Elements sind. Um die Verwendung von Erweiterungen sicher und handhabbar zu machen, gibt es einen strikten Governance-Prozess für die Definition und Verwendung von Erweiterungen. Obwohl jeder Implementierer eine Erweiterung definieren kann, gibt es Anforderungen, die im Rahmen der Definition der Erweiterung erfüllt werden MÜSSEN."
-  * ^comment = "Es darf kein Stigma mit der Verwendung von Erweiterungen durch eine beliebige Anwendung, ein Projekt oder einen Standard verbunden sein - unabhängig von der Institution oder Gerichtsbarkeit, die die Erweiterungen verwendet oder definiert. Die Verwendung von Erweiterungen ermöglicht es der FHIR-Spezifikation, für alle einen einfachen Kern beizubehalten."
-
-* repeat.bounds[x]
+* repeat.bounds[x] MS
   * ^short = "Länge/Bereich der Längen oder (Start- und/oder End-)Grenzen"
   * ^definition = "Entweder eine Dauer für die Länge des Zeitplans, ein Bereich möglicher Längen oder äußere Begrenzungen für Start- und/oder Endgrenzen des Zeitplans."
   * ^comment = "tbd"
-
 * repeat.boundsDuration MS
   * ^short = "Dauer der Dosieranweisung ausgedrückt in UCUM-Einheiten"
   * ^definition = "Entweder eine Dauer für die Länge des Zeitplans, ein Bereich möglicher Längen oder äußere Begrenzungen für Start- und/oder Endgrenzen des Zeitplans."
   * system = $ucum (exactly)
-
-* repeat.count
-  * ^short = "Anzahl der Wiederholungen"
-  * ^definition = "Gesamtanzahl der gewünschten Wiederholungen über die gesamte Dauer des Zeitplans. Falls countMax vorhanden ist, gibt dieses Element die Untergrenze des zulässigen Bereichs der Wiederholungsanzahl an."
-  * ^comment = "Wenn sowohl Grenzen als auch Anzahl angegeben sind, sollte dies so verstanden werden, dass innerhalb des Zeitraums bis zu count-mal wiederholt wird."
-
-* repeat.countMax
-  * ^short = "Maximale Anzahl der Wiederholungen"
-  * ^definition = "Falls vorhanden, zeigt dies an, dass die Anzahl ein Bereich ist - also die Aktion zwischen count und countMax Mal auszuführen ist."
-  * ^comment = "tbd"
-
-* repeat.duration
-  * ^short = "Wie lange, wenn es passiert"
-  * ^definition = "Wie lange dieses Ereignis jeweils andauert. Falls durationMax vorhanden ist, gibt dieses Element die Untergrenze des zulässigen Bereichs der Dauer an."
-  * ^comment = "Für manche Ereignisse ist die Dauer Teil der Ereignisdefinition (z. B. Infusionen, bei denen die Dauer durch die angegebene Menge und Rate implizit ist). Für andere ist es Teil der Timing-Spezifikation (z. B. Sport)."
-
-* repeat.durationMax
-  * ^short = "Wie lange, wenn es passiert (Max)"
-  * ^definition = "Falls vorhanden, zeigt dies an, dass die Dauer ein Bereich ist - also die Aktion zwischen duration und durationMax Zeitlänge auszuführen ist."
-  * ^comment = "Für manche Ereignisse ist die Dauer Teil der Ereignisdefinition (z. B. Infusionen, bei denen die Dauer durch die angegebene Menge und Rate implizit ist). Für andere ist es Teil der Timing-Spezifikation (z. B. Sport)."
-
-* repeat.durationUnit
-  * ^short = "s | min | h | d | wk | mo | a - Zeiteinheit (UCUM)"
-  * ^definition = "Die Zeiteinheit für die Dauer, in UCUM-Einheiten."
-  * ^comment = "tbd"
-
-* repeat.frequency
+    * ^short = "UCUM-Einheit für die Dauer" 
+    * ^comment = "Die UCUM-Einheit für die Dauer, z. B. d für Tag, h für Stunde, min für Minute."
+* repeat.frequency MS
   * ^short = "Ereignis tritt frequency-mal pro Zeitraum auf"
   * ^definition = "Die Anzahl der Wiederholungen innerhalb des angegebenen Zeitraums. Falls frequencyMax vorhanden ist, gibt dieses Element die Untergrenze des zulässigen Bereichs der Häufigkeit an."
-  * ^comment = "tbd"
-
-* repeat.frequencyMax
-  * ^short = "Ereignis tritt bis zu frequencyMax-mal pro Zeitraum auf"
-  * ^definition = "Falls vorhanden, zeigt dies an, dass die Häufigkeit ein Bereich ist - also zwischen frequency und frequencyMax Mal pro Zeitraum oder Zeitraumspanne wiederholt wird."
-  * ^comment = "tbd"
-
-* repeat.period
+* repeat.period MS
   * ^short = "Ereignis tritt frequency-mal pro Zeitraum auf"
   * ^definition = "Gibt die Zeitspanne an, über die die Wiederholungen stattfinden sollen; z. B. um „3-mal täglich“ auszudrücken, wäre 3 die Häufigkeit und „1 Tag“ der Zeitraum. Falls periodMax vorhanden ist, gibt dieses Element die Untergrenze des zulässigen Bereichs der Zeitspanne an."
-  * ^comment = "tbd"
-
-* repeat.periodMax
-  * ^short = "Obergrenze des Zeitraums (z. B. 3-4 Stunden)"
-  * ^definition = "Falls vorhanden, zeigt dies an, dass der Zeitraum ein Bereich von period bis periodMax ist, was z. B. Konzepte wie „einmal alle 3-5 Tage“ ausdrücken kann."
-  * ^comment = "tbd"
-
 * repeat.periodUnit
   * ^short = "s | min | h | d | wk | mo | a - Zeiteinheit (UCUM)"
   * ^definition = "Die Zeiteinheit für den Zeitraum, in UCUM-Einheiten."
-  * ^comment = "tbd"
-
-* repeat.dayOfWeek
+* repeat.dayOfWeek MS
   * ^short = "mon | tue | wed | thu | fri | sat | sun"
   * ^definition = "Wenn ein oder mehrere Wochentage angegeben sind, findet die Aktion nur an den angegebenen Tagen statt."
-  * ^comment = "Wenn keine Tage angegeben sind, wird angenommen, dass die Aktion an jedem Tag wie sonst angegeben stattfindet. Die Elemente frequency und period können nicht zusammen mit dayOfWeek verwendet werden."
-
-* repeat.timeOfDay
+  * ^comment = "Wenn keine Tage angegeben sind, wird angenommen, dass die Aktion an jedem Tag wie sonst angegeben stattfindet."
+* repeat.timeOfDay MS
   * ^short = "Tageszeit für die Aktion"
   * ^definition = "Angegebene Tageszeit, zu der die Aktion stattfinden soll."
-  * ^comment = "Wenn eine Tageszeit angegeben ist, wird angenommen, dass die Aktion jeden Tag (ggf. gefiltert durch dayOfWeek) zu den angegebenen Zeiten stattfindet. Die Elemente when, frequency und period können nicht zusammen mit timeOfDay verwendet werden."
-
-* repeat.when
+  * ^comment = "Wenn eine Tageszeit angegeben ist, wird angenommen, dass die Aktion jeden Tag (ggf. gefiltert durch dayOfWeek) zu den angegebenen Zeiten stattfindet."
+* repeat.when MS
   * ^short = "Code für den Zeitraum des Auftretens"
   * ^definition = "Ein ungefährer Zeitraum während des Tages, der möglicherweise mit einem Ereignis des täglichen Lebens verknüpft ist und angibt, wann die Aktion stattfinden soll."
   * ^comment = "Wenn mehr als ein Ereignis angegeben ist, bezieht sich das Ereignis auf die Vereinigung der angegebenen Ereignisse."
-
-* repeat.offset
-  * ^short = "Minuten vom Ereignis (vorher oder nachher)"
-  * ^definition = "Die Anzahl der Minuten vom Ereignis. Wenn der Ereigniscode nicht angibt, ob die Minuten vor oder nach dem Ereignis liegen, wird angenommen, dass der Offset nach dem Ereignis ist."
-  * ^comment = "tbd"
-
-* code
-  * ^short = "BID | TID | QID | AM | PM | QD | QOD | +"
-  * ^definition = "Ein Code für den Zeitplan (oder nur Text in code.text). Einige Codes wie BID sind weit verbreitet, aber viele Institutionen definieren eigene zusätzliche Codes. Wenn ein Code angegeben ist, wird er als vollständige Aussage dessen verstanden, was in den strukturierten Timing-Daten angegeben ist, und entweder der Code oder die Daten können zur Interpretation des Timings verwendet werden, mit der Ausnahme, dass .repeat.bounds weiterhin für den Code gilt (und nicht im Code enthalten ist)."
-  * ^comment = "BID usw. sind als „zu institutionell festgelegten Zeiten“ definiert. Zum Beispiel kann eine Institution festlegen, dass BID immer um 7 Uhr und 18 Uhr ist. Wenn es nicht angebracht ist, dass diese Wahl getroffen wird, sollte der Code BID nicht verwendet werden. Stattdessen sollte ein spezifischer, organisationsspezifischer Code anstelle des HL7-definierten BID-Codes verwendet und/oder eine strukturierte Darstellung genutzt werden (in diesem Fall mit Angabe der beiden Ereigniszeiten)."

--- a/input/fsh/datatypes/timing_de_dgmp.fsh
+++ b/input/fsh/datatypes/timing_de_dgmp.fsh
@@ -11,11 +11,12 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * bounds[x] MS
   * bounds[x] only Duration
   * boundsDuration MS
-  * boundsDuration.code from DosageUnitsOfTimeDgMP (required)
+  * boundsDuration.code from DurationUnitsOfTimeDgMPVS (required)
 
-  * frequency MS
-  * period MS
-  * periodUnit MS
+  * frequency 1.. MS
+  * period 1.. MS
+  * periodUnit 1.. MS
+  * periodUnit from PeriodUnitsOfTimeDgMPVS (required)
   * dayOfWeek MS
   * timeOfDay MS
   * when MS
@@ -31,11 +32,12 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * periodMax 0..0
   * offset 0..0
 
+//TODO Invariant info auf Teile der Invariante.
 Invariant: timing-only-one-type
 Description: "Only one kind of Timing is allowed. Current allowed timings: 4-Scheme, TimeOfDay, DayOfWeek, Interval, DayOfWeek and Time/4-Schema, Interval and Time/4-Schema"
 Expression: "
 /* 4-Schema */
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 timing.repeat.frequency.exists() and timing.repeat.frequency = 1 and
 timing.repeat.period.exists() and timing.repeat.period = 1 and
 timing.repeat.periodUnit.exists() and timing.repeat.periodUnit = 'd' and
@@ -45,7 +47,7 @@ timing.repeat.dayOfWeek.empty()
 ) or
 
 /* TimeOfDay */
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 timing.repeat.timeOfDay.exists() and
 timing.repeat.frequency.exists() and timing.repeat.frequency = 1 and
 timing.repeat.period.exists() and timing.repeat.period = 1 and
@@ -55,7 +57,7 @@ timing.repeat.dayOfWeek.empty()
 ) or
 
 /* DayOfWeek */
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 timing.repeat.dayOfWeek.exists() and
 timing.repeat.frequency.exists() and timing.repeat.frequency = 1 and
 timing.repeat.period.exists() and timing.repeat.period = 1 and
@@ -65,7 +67,7 @@ timing.repeat.timeOfDay.empty()
 ) or
 
 /* Interval */
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 timing.repeat.frequency.exists() and
 timing.repeat.period.exists() and
 timing.repeat.periodUnit.exists() and
@@ -75,7 +77,7 @@ timing.repeat.dayOfWeek.empty()
 ) or
 
 /* DayOfWeek and Time/4-Schema */
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 timing.repeat.dayOfWeek.exists() and
 timing.repeat.frequency.exists() and timing.repeat.frequency = 1 and
 timing.repeat.period.exists() and timing.repeat.period = 1 and
@@ -87,7 +89,7 @@ timing.repeat.periodUnit.exists() and timing.repeat.periodUnit = 'd' and
 ) or
 
 /* Interval and Time/4-Schema */
-%resource.(ofType(MedicationRequest).dosageInstruction | ofType(MedicationStatement).dosage).all(
+(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 timing.repeat.frequency.exists() and
 timing.repeat.period.exists() and
 timing.repeat.periodUnit.exists() and

--- a/input/fsh/examples/dev_examples_invalid.fsh
+++ b/input/fsh/examples/dev_examples_invalid.fsh
@@ -1,36 +1,37 @@
-Instance: Example-MR-Dosage-Invalid-1-Dosage-FrequencyOnly
-InstanceOf: MedicationRequestDgMP
-Usage: #example
-Title: "Example-MR-Dosage-DEV"
-Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It only checks for invalid Permutations"
-* subject.display = "DEV Dosage"
-* status = #active
-* intent = #order
-* medicationCodeableConcept.text = "DEV Medication"
-* dosageInstruction[+] = Invalid-Dosage-FrequencyOnly
+// Instance: Example-MR-Dosage-Invalid-1-Dosage-FrequencyOnly
+// InstanceOf: MedicationRequestDgMP
+// Usage: #example
+// Title: "Example-MR-Dosage-DEV"
+// Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It only checks for invalid Permutations"
+// * subject.display = "DEV Dosage"
+// * status = #active
+// * intent = #order
+// * medicationCodeableConcept.text = "DEV Medication"
+// * dosageInstruction[+] = Invalid-Dosage-FrequencyOnly
 
-Instance: Invalid-Dosage-FrequencyOnly
-InstanceOf: DosageDgMP
-Usage: #inline
-Title: "Invalid: frequency only"
-* timing.repeat.frequency = 1
+// Instance: Invalid-Dosage-FrequencyOnly
+// InstanceOf: DosageDgMP
+// Usage: #inline
+// Title: "Invalid: frequency only"
+// * timing
+//   * repeat.frequency = 1
 
-Instance: Example-MR-Dosage-Invalid-2-Dosage-FreqPeriod
-InstanceOf: MedicationRequestDgMP
-Usage: #example
-Title: "Example-MR-Dosage-DEV"
-Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It only checks for invalid Permutations"
-* subject.display = "DEV Dosage"
-* status = #active
-* intent = #order
-* medicationCodeableConcept.text = "DEV Medication"
-* dosageInstruction[+] = Invalid-Dosage-FreqPeriod
+// Instance: Example-MR-Dosage-Invalid-2-Dosage-FreqPeriod
+// InstanceOf: MedicationRequestDgMP
+// Usage: #example
+// Title: "Example-MR-Dosage-DEV"
+// Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It only checks for invalid Permutations"
+// * subject.display = "DEV Dosage"
+// * status = #active
+// * intent = #order
+// * medicationCodeableConcept.text = "DEV Medication"
+// * dosageInstruction[+] = Invalid-Dosage-FreqPeriod
 
-Instance: Invalid-Dosage-FreqPeriod
-InstanceOf: DosageDgMP
-Usage: #inline
-Title: "Invalid: frequency only"
-* timing.repeat.frequency = 1
+// Instance: Invalid-Dosage-FreqPeriod
+// InstanceOf: DosageDgMP
+// Usage: #inline
+// Title: "Invalid: frequency only"
+// * timing.repeat.frequency = 1
 
 Instance: Example-MR-Dosage-Invalid-3-Dosage-When-TimeOfDay
 InstanceOf: MedicationRequestDgMP
@@ -47,8 +48,13 @@ Instance: Invalid-Dosage-When-TimeOfDay
 InstanceOf: DosageDgMP
 Usage: #inline
 Title: "Invalid: when and timeOfDay"
-* timing.repeat.when[+] = #MORN
-* timing.repeat.timeOfDay[+] = "08:00:00"
+* timing
+  * repeat
+    * when[+] = #MORN
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
 
 Instance: Example-MR-Dosage-Invalid-4-Dosage-TimeOfDay-DayOfWeek
 InstanceOf: MedicationRequestDgMP
@@ -65,8 +71,13 @@ Instance: Invalid-Dosage-TimeOfDay-DayOfWeek
 InstanceOf: DosageDgMP
 Usage: #inline
 Title: "Invalid: timeOfDay and dayOfWeek"
-* timing.repeat.timeOfDay[+] = "08:00:00"
-* timing.repeat.dayOfWeek[+] = #mon
+* timing
+  * repeat
+    * dayOfWeek[+] = #mon
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
 
 Instance: Example-MR-Dosage-Invalid-5-Dosage-When-TimeOfDay-DayOfWeek
 InstanceOf: MedicationRequestDgMP
@@ -83,9 +94,14 @@ Instance: Invalid-Dosage-When-TimeOfDay-DayOfWeek
 InstanceOf: DosageDgMP
 Usage: #inline
 Title: "Invalid: when, timeOfDay, and dayOfWeek"
-* timing.repeat.when[+] = #MORN
-* timing.repeat.timeOfDay[+] = "08:00:00"
-* timing.repeat.dayOfWeek[+] = #mon
+* timing
+  * repeat
+    * when[+] = #MORN
+    * timeOfDay[+] = "08:00:00"
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
 
 Instance: Example-MR-Dosage-Invalid-6-Dosage-FreqPeriod-When
 InstanceOf: MedicationRequestDgMP
@@ -149,25 +165,6 @@ Title: "Invalid: freq/period/periodUnit, when, and dayOfWeek"
 * timing.repeat.when[+] = #MORN
 * timing.repeat.dayOfWeek[+] = #mon
 
-Instance: Example-MR-Dosage-Invalid-9-Dosage-Freq-TimeOfDay-When
-InstanceOf: MedicationRequestDgMP
-Usage: #example
-Title: "Example-MR-Dosage-DEV"
-Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It only checks for invalid Permutations"
-* subject.display = "DEV Dosage"
-* status = #active
-* intent = #order
-* medicationCodeableConcept.text = "DEV Medication"
-* dosageInstruction[+] = Invalid-Dosage-Freq-TimeOfDay-When
-
-Instance: Invalid-Dosage-Freq-TimeOfDay-When
-InstanceOf: DosageDgMP
-Usage: #inline
-Title: "Invalid: frequency, timeOfDay, and when"
-* timing.repeat.frequency = 1
-* timing.repeat.timeOfDay[+] = "08:00:00"
-* timing.repeat.when[+] = #MORN
-
 Instance: Example-MR-Dosage-Invalid-10-Dosage-FreeText-and-structured
 InstanceOf: MedicationRequestDgMP
 Usage: #example
@@ -184,7 +181,12 @@ InstanceOf: DosageDgMP
 Usage: #inline
 Title: "Invalid: when and structured"
 * text = "Einmal am Tag um 20:00"
-* timing.repeat.when[+] = #MORN
+* timing
+  * repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
 
 Instance: Example-MR-Dosage-Invalid-11-Dosage-multiple-types
 InstanceOf: MedicationRequestDgMP

--- a/input/fsh/examples/scheme_examples_interval.fsh
+++ b/input/fsh/examples/scheme_examples_interval.fsh
@@ -1,8 +1,8 @@
-Instance: Example-MR-Dosage-interval-8h
+Instance: Example-MR-Dosage-interval-8d
 InstanceOf: MedicationRequestDgMP
 Usage: #example
-Title: "Example-MR-Dosage-interval-8h"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Tablette alle 8 Stunden dar"
+Title: "Example-MR-Dosage-interval-8d"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Tablette alle 8 Tage dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -10,7 +10,7 @@ Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosie
 * dosageInstruction[+]
   * timing.repeat.frequency = 1
   * timing.repeat.period = 8
-  * timing.repeat.periodUnit = #h
+  * timing.repeat.periodUnit = #d
   * doseAndRate.doseQuantity.value = 1
   * doseAndRate.doseQuantity.unit = "Tablette"
 

--- a/input/fsh/examples/unsupported_examples.fsh
+++ b/input/fsh/examples/unsupported_examples.fsh
@@ -14,7 +14,13 @@ InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: Count"
 * text = "count"
-* timing.repeat.count = 5
+* timing
+  * repeat
+    * count = 5
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+
 
 Instance: MR-Unsupported-Dosage-2-asNeededBoolean
 InstanceOf: MedicationRequestDgMP
@@ -281,7 +287,12 @@ InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: Count"
 * text = "count"
-* timing.repeat.count = 5
+* timing
+  * repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * count = 5
 
 Instance: MR-Unsupported-Dosage-16-CountMax
 InstanceOf: MedicationRequestDgMP
@@ -298,8 +309,12 @@ Instance: Unsupported-Dosage-16-CountMax
 InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: CountMax"
-* text = "countMax"
-* timing.repeat.countMax = 10
+* timing
+  * repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * countMax = 10
 
 Instance: MR-Unsupported-Dosage-17-BoundsPeriod
 InstanceOf: MedicationRequestDgMP
@@ -317,8 +332,13 @@ InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: BoundsPeriod"
 * text = "boundsPeriod"
-* timing.repeat.boundsPeriod.start = "2023-01-01"
-* timing.repeat.boundsPeriod.end = "2023-01-31"
+* timing
+  * repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * boundsPeriod.start = "2023-01-01"
+    * boundsPeriod.end = "2023-01-31"
 
 Instance: MR-Unsupported-Dosage-18-BoundsRange
 InstanceOf: MedicationRequestDgMP
@@ -336,10 +356,15 @@ InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: BoundsRange"
 * text = "boundsRange"
-* timing.repeat.boundsRange.low.value = 1
-* timing.repeat.boundsRange.low.unit = "d"
-* timing.repeat.boundsRange.high.value = 10
-* timing.repeat.boundsRange.high.unit = "d"
+* timing
+  * repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * boundsRange.low.value = 1
+    * boundsRange.low.unit = "d"
+    * boundsRange.high.value = 10
+    * boundsRange.high.unit = "d"
 
 Instance: MR-Unsupported-Dosage-19-Offset
 InstanceOf: MedicationRequestDgMP
@@ -356,8 +381,12 @@ Instance: Unsupported-Dosage-19-Offset
 InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: Offset"
-* text = "offset"
-* timing.repeat.offset = 30
+* timing
+  * repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * offset = 30
 
 Instance: MR-Unsupported-Dosage-20-Event
 InstanceOf: MedicationRequestDgMP
@@ -374,7 +403,13 @@ Instance: Unsupported-Dosage-20-Event
 InstanceOf: DosageDE
 Usage: #inline
 Title: "Unsupported: Event"
-* text = "event"
-* timing.event[0] = "2023-06-01T08:00:00+01:00"
-* timing.repeat.boundsDuration.value = 3
-* timing.repeat.boundsDuration.unit = "Woche(n)"
+* timing
+  * event[0] = "2023-06-01T08:00:00+01:00"
+  * repeat
+    * when[+] = #MORN
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * boundsDuration.value = 3
+    * boundsDuration.unit = "Woche(n)"

--- a/input/fsh/terminologies/DosageDoseQuantityDGMP-VS.fsh
+++ b/input/fsh/terminologies/DosageDoseQuantityDGMP-VS.fsh
@@ -2,7 +2,6 @@ ValueSet: DosageDoseQuantityDGMPVS
 Id: DosageDoseQuantityDGMP
 Title: "Dosage Dose-Quantity ValueSet DGMP"
 Description: "Diese ValueSet enthält die erlaubten Konzepte für die Dosierungseinheit in der Dosiermenge DGMP."
-* include codes from system $kbv-dosiereinheit
 * $edqm#15017000 "Cup"
 * $edqm#15016000 "Behältnis (Container, Pkg.)"
 * $edqm#15009000 "Flasche"

--- a/input/fsh/terminologies/DoseQuantityDgMP-CM.fsh
+++ b/input/fsh/terminologies/DoseQuantityDgMP-CM.fsh
@@ -1,7 +1,7 @@
 Instance: KBV-CS-SFHIR-BMP-DOSIEREINHEIT-to-EDQM-UCUM
 InstanceOf: ConceptMap
 Usage: #definition
-* url = "http://fhir.de/ConceptMap/KBV-CS-SFHIR-BMP-DOSIEREINHEIT-to-EDQM-UCUM"
+* url = "http://ig.fhir.de/igs/medication/ConceptMap/KBV-CS-SFHIR-BMP-DOSIEREINHEIT-to-EDQM-UCUM"
 * status = #draft
 * targetCanonical = Canonical(DosageDoseQuantityDGMPVS)
 * group[0].source = $kbv-dosiereinheit

--- a/input/fsh/terminologies/DurationUnitsOfTimeDgMP-VS.fsh
+++ b/input/fsh/terminologies/DurationUnitsOfTimeDgMP-VS.fsh
@@ -1,7 +1,7 @@
-ValueSet: DosageUnitsOfTimeDgMP
+ValueSet: DurationUnitsOfTimeDgMPVS
 Id: DosageUnitsOfTimeDgMP
-Title: "Zeiteinheiten für Dosierungen"
-Description: "Dieses ValueSet enthält Zeiteinheiten aus dem UCUM-CodeSystem in deutscher Übersetzung."
+Title: "Zeiteinheiten für die DurationUnit in Dosierungen im dgMP"
+Description: "Dieses ValueSet enthält dgMPV DurationUnit Zeiteinheiten aus dem UCUM-CodeSystem in deutscher Übersetzung"
 * include $ucum#d 
   * ^designation.language = #de-DE
   * ^designation.value = "Tag(e)"

--- a/input/fsh/terminologies/PeriodUnitsOfTimeDgMP-VS.fsh
+++ b/input/fsh/terminologies/PeriodUnitsOfTimeDgMP-VS.fsh
@@ -1,0 +1,13 @@
+ValueSet: PeriodUnitsOfTimeDgMPVS
+Id: PeriodUnitsOfTimeDgMP
+Title: "Zeiteinheiten für PeriodUnit in Dosierungen im dgMP"
+Description: "Dieses ValueSet enthält dgMPV PeriodUnit Zeiteinheiten aus dem UCUM-CodeSystem in deutscher Übersetzung"
+* include $ucum#d 
+  * ^designation.language = #de-DE
+  * ^designation.value = "Tag(e)"
+* include $ucum#wk
+  * ^designation.language = #de-DE
+  * ^designation.value = "Woche(n)"
+* include $ucum#mo
+  * ^designation.language = #de-DE
+  * ^designation.value = "Monat"

--- a/input/pagecontent/timing-interval-scheme.md
+++ b/input/pagecontent/timing-interval-scheme.md
@@ -9,7 +9,7 @@ Es kann nur für Arzneimittel mit der Einheit "Stück" verwendet werden. Es trif
 
 ## Beipiel
 
-{% fragment MedicationRequest/Example-MR-Dosage-interval-8h JSON %}
+{% fragment MedicationRequest/Example-MR-Dosage-interval-8d JSON %}
 
 Folgende weitere Beispiele sind in diesem IG dargestellt:
 

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,0 +1,14 @@
+{
+  "package-id" : "de.fhir.medication",
+  "version" : "ballot1",
+  "path" : "http://ig.fhir.de/igs/medication/1.0.0-ballot1",
+  "mode" : "milestone",
+  "status" : "draft",
+  "sequence" : "Releases",
+  "desc" : "Initial release ballot release",
+  "first" : true,
+  "title" : "Medication IG DE",
+  "ci-build" : "https://build.fhir.org/ig/hl7germany/medication-ig-de-r4",
+  "category" : "National Base",
+  "introduction" : "This IG is the first ballot release of the Medication IG DE. It provides a set of profiles and extensions for medication management,currently focused on Dosage and Timing, in Germany, based on FHIR R4."
+}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,16 +3,16 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: de.medication.r4
-canonical: http://fhir.de
+id: de.fhir.medication
+canonical: http://ig.fhir.de/igs/medication
 name: MedicationDE
 title: Medication IG DE
 # description: Example Implementation Guide for getting started with SUSHI
 status: draft # draft | active | retired | unknown
-version: 0.1.0
+version: 1.0.0-ballot1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
-releaseLabel: draft
+releaseLabel: 1.0.0
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:


### PR DESCRIPTION
This pull request introduces significant updates to FHIR profiles and configurations to align with Germany-wide standards for medication dosage and timing. The changes streamline definitions, remove unused fields, and refine constraints to improve clarity and compliance. Key changes include updates to the `DosageDE` and `TimingDE` profiles, adjustments to the `DosageDgMP` profile, and modifications to the invariant expressions for dosage instructions.

### Updates to FHIR Profiles

#### Dosage Profile Updates:
* [`input/fsh/datatypes/dosage_de.fsh`](diffhunk://#diff-3ce49227a5453fc16752613d2f1db224c0d0eb0f5e5ac0532a09dba3dbfcbb83R1-R25): Simplified the `DosageDE` profile by removing unused fields (e.g., `sequence`, `additionalInstruction`, `patientInstruction`) and refining constraints on `timing` and `doseAndRate`. Added new comments to clarify the usage of `Dosage.text` and `GeneratedDosageInstructions`.

* [`input/fsh/datatypes/dosage_dgmp.fsh`](diffhunk://#diff-fc95807902e8face4a8e40bf0369d9967720ececb6a4b6153dde12db8fd2bcd5L6-R24): Adjusted the `DosageDgMP` profile to remove unused fields like `additionalInstruction` and `patientInstruction`. Updated constraints to ensure structured or free-text dosage instructions are mutually exclusive.

#### Timing Profile Updates:
* [`input/fsh/datatypes/timing_de.fsh`](diffhunk://#diff-c090a25b2773cb1d2ff4b536047e316d9f168ed8563edeb532a96fc6005f2e2bL6-L125): Enhanced the `TimingDE` profile by making `repeat`, `repeat.bounds[x]`, and `repeat.frequency` mandatory. Removed redundant fields (e.g., `repeat.count`, `repeat.durationUnit`) and clarified the definitions for timing attributes.

### Configuration Updates

* [`ig.ini`](diffhunk://#diff-35be1a32ce72a33e8bf8768fc2845c7727d15743e1242683c451ad5c0be864ddL2-R2): Updated the Implementation Guide file path to reflect the new naming convention (`ImplementationGuide-de.fhir.medication.json`) and adjusted the template settings.

### Invariant Adjustments

* [`input/fsh/datatypes/dosage_dgmp.fsh`](diffhunk://#diff-fc95807902e8face4a8e40bf0369d9967720ececb6a4b6153dde12db8fd2bcd5L41-R36): Modified the invariant expression `DosageStructuredOrFreeText` to include `MedicationDispense` dosage instructions, ensuring consistency across related resources.