### PR TITLE
remove dependency to kbv st package

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,8 +24,7 @@ publisher:
 # package id and the value is the version (or dev/current). For advanced
 # use cases, the value can be an object with keys for id, uri, and version.
 #
-dependencies:
-  kbv.all.st: 1.23.0
+# dependencies:
 #   hl7.fhir.us.mcode:
 #     id: mcode
 #     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode


### PR DESCRIPTION
This pull request makes a small adjustment to the `sushi-config.yaml` file, specifically removing the `kbv.all.st` dependency and its version while commenting out the `dependencies` section entirely.