### PR TITLE
add build and publish scripts; update publication request for first ballot release

### DIFF
--- a/publication-request.json
+++ b/publication-request.json
@@ -3,12 +3,12 @@
   "version" : "ballot1",
   "path" : "http://ig.fhir.de/igs/medication/1.0.0-ballot1",
   "mode" : "milestone",
-  "status" : "draft",
+  "status" : "ballot",
   "sequence" : "Releases",
-  "desc" : "Initial release ballot release",
+  "desc" : "First ballot release of the Medication IG DE",
   "first" : true,
   "title" : "Medication IG DE",
   "ci-build" : "https://build.fhir.org/ig/hl7germany/medication-ig-de-r4",
-  "category" : "National Base",
+  "category" : "Medications",
   "introduction" : "This IG is the first ballot release of the Medication IG DE. It provides a set of profiles and extensions for medication management,currently focused on Dosage and Timing, in Germany, based on FHIR R4."
 }

--- a/scripts/build-publish.sh
+++ b/scripts/build-publish.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+bash scripts/build-ig.sh
+bash scripts/prepare-publish.sh

--- a/scripts/prepare-publish.sh
+++ b/scripts/prepare-publish.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+echo "Starte Prepare-Publish-Skript: $(date '+%Y-%m-%d %H:%M:%S')"
+
+# Zielordner immer neu anlegen
+rm -rf medication-no-sushi
+mkdir -p medication-no-sushi
+
+# 2) output, custom-template und input rekursiv kopieren
+cp -r output medication-no-sushi/
+cp -r custom-template medication-no-sushi/
+cp -r input medication-no-sushi/
+
+# 3) Danach den Ordner fsh im kopierten input leeren
+rm -rf medication-no-sushi/input/fsh/*
+
+# 4) Ressourcen und Includes aus FSH-Generierung übernehmen
+mkdir -p medication-no-sushi/input/resources
+mkdir -p medication-no-sushi/input/examples
+
+# Kopiere alle Ressourcen mit Namen beginnend mit "Medication" in examples
+find fsh-generated/resources -maxdepth 1 -type f -name 'Medication*' -exec cp {} medication-no-sushi/input/examples/ \;
+# Kopiere alle anderen Ressourcen in resources
+find fsh-generated/resources -maxdepth 1 -type f ! -name 'Medication*' -exec cp {} medication-no-sushi/input/resources/ \;
+
+# Entfernen der automatisch generierten ImplementationGuide-Dateien
+rm medication-no-sushi/input/resources/ImplementationGuide*.json
+
+mkdir -p medication-no-sushi/input/includes
+
+# 5) Konfigurationsdateien übernehmen
+cp sushi-config.yaml medication-no-sushi/
+cp ig.ini medication-no-sushi/
+cp publication-request.json medication-no-sushi/
+echo "Fertig mit Prepare-Publish-Skript: $(date '+%Y-%m-%d %H:%M:%S')"


### PR DESCRIPTION
This pull request introduces updates to the publication request configuration and adds new scripts for building and preparing the publication of the Medication IG DE. The most notable changes include modifying metadata in `publication-request.json` to reflect the ballot release, adding a new build script, and creating a detailed script for preparing publication resources.

### Updates to publication metadata:

* [`publication-request.json`](diffhunk://#diff-5a1dd5a743b074aee2ee813472f237a649d5c42fb46c9e6fd0bbc66a519755b7L6-R12): Changed `status` from "draft" to "ballot," updated `desc` to describe the first ballot release, and changed `category` to "Medications" to better align with the IG's focus.

### Addition of build and publication scripts:

* [`scripts/build-publish.sh`](diffhunk://#diff-9f268c68accf02493b56d5c323b22ca3a4adbfd2cc17eaceca4df1ae680cc9e9R1-R4): Added a new script to streamline the process of building and preparing the publication by chaining the execution of `build-ig.sh` and `prepare-publish.sh`.
* [`scripts/prepare-publish.sh`](diffhunk://#diff-101f51bb0a88d1befe947fd5f51f2050052466e8c2ae512de37ad91bd21d513fR1-R34): Created a comprehensive script to prepare publication resources, including folder setup, copying necessary files, cleaning up generated resources, and organizing configuration files.