### PR TITLE
refactor: update timing descriptions

### DIFF
--- a/input/pagecontent/timing-interval-scheme.md
+++ b/input/pagecontent/timing-interval-scheme.md
@@ -1,11 +1,10 @@
 # Schema für Wiederkehrendes Zeitinterval
 
-Dieses Schema basiert auf definierten Zeitintervallen, anhand derer sich die Anwendung des Arzneimittels wiederholt. Das Intervall kann in verschiedenen Zeiteinheiten angegeben werden, also z.B. in Tagen, Wochen oder Monaten. Für jedes Intervall wird angegeben, in welcher Frequenz die Anwendung innerhalb des Intervalls erfolgen soll.
+Dieses Schema basiert auf definierten Zeitintervallen, anhand derer sich die Anwendung des Arzneimittels wiederholt. Das Intervall kann in verschiedenen Zeiteinheiten angegeben werden, also z.B. in Tagen, Wochen oder Monaten. Für jedes Intervall wird angegeben, in welcher Frequenz die Anwendung innerhalb des Intervalls erfolgen soll. Es trifft  keine Aussage darüber, zu welchem spezifischen Zeitpunkt das Arzneimittel anzuwenden ist (bspw. als Uhrzeit, Tageszeit oder Wochentag). 
+
 In diesem Anwendungsfall wird davon ausgegangen, dass sich das Schema ohne Variation der Länge eines Intervalls oder der Frequenz der Anwendung wiederholt. Es wird zudem ermöglicht:
 
-- die geplante Dauer der Anwendung zu begrenzten. 
-
-Es kann nur für Arzneimittel mit der Einheit "Stück" verwendet werden. Es trifft außerdem keine Aussage darüber, zu welchem spezifischen Zeitpunkt das Arzneimittel anzuwenden ist (bspw. als Uhrzeit, Tageszeit oder Wochentag). 
+- die geplante Dauer der Anwendung zu begrenzen (bsp. in Tagen). 
 
 ## Beipiel
 

--- a/input/pagecontent/timing-mman-scheme.md
+++ b/input/pagecontent/timing-mman-scheme.md
@@ -2,10 +2,11 @@
 
 Dieses Schema unterteilt den Tag in die Tageszeiten "Morgen", "Mittag", "Abend" und "Nacht".
 Es gibt an, zu welchen dieser vier Tageszeiten das Medikament angewandt werden soll. Das Tageszeitenschema wird auch "Viererschema" oder "MMAN-Schema" genannt und häufig als Kette von vier Zahlen abgebildet (z.B. 1-0-1-0). 
+
 In diesem Anwendungsfall wird davon ausgegangen, dass das Arzneimittel (für die geplante Dauer) täglich in einem gleichbleibenden Tageszeitenschema angewandt wird. Es wird zudem ermöglicht:
 
-- eine abweichende Dosis abhängig von der Tageszeit anzugeben
-- die geplante Dauer der Anwendung zu begrenzen (bsp. in Tagen). 
+- die geplante Dauer der Anwendung zu begrenzen (bspw. in Tagen)
+- eine abweichende Dosis abhängig von der Tageszeit anzugeben (in einer weiteren Dosage-Instanz).
 
 ## Beipiel
 

--- a/input/pagecontent/timing-timeofday-scheme.md
+++ b/input/pagecontent/timing-timeofday-scheme.md
@@ -3,8 +3,8 @@
 Dieses Schema bietet die Möglichkeit, die Dosierung zu exakt festgelegten Zeiten an einem Tag zu planen (z.B. 08:00 und 12:00 Uhr). 
 In diesem Anwendungsfall wird davon ausgegangen, dass das Arzneimittel (für die geplante Dauer) täglich in einem gleichbleibenden Uhrzeitenschema angewandt wird. Es wird zudem ermöglicht:
 
-- eine abweichende Dosis abhängig von der Uhrzeit anzugeben und
-- die geplante Dauer der Anwendung zu begrenzen (bsp. in Tagen). 
+- die geplante Dauer der Anwendung zu begrenzen (bspw. in Tagen)
+- eine abweichende Dosis abhängig von der Uhrzeit anzugeben (in einer weiteren Dosage-Instanz).
 
 ## Beipiel
 

--- a/input/pagecontent/timing-weekday-scheme.md
+++ b/input/pagecontent/timing-weekday-scheme.md
@@ -3,8 +3,8 @@
 Dieses Schema gibt an, an welchen Wochentagen einer Kalenderwoche das Medikament angewandt werden soll.
 In diesem Anwendungsfall wird davon ausgegangen, dass das Arzneimittel wöchentlich (für die geplante Dauer) in einem gleichbleibenden Wochentagsschema angewandt wird. Es wird zudem ermöglicht:
 
-- eine abweichende Dosis abhängig vom Wochentag anzugeben und
-- die geplante Dauer der Anwendung zu begrenzen. 
+- die geplante Dauer der Anwendung zu begrenzen (bspw. in Tagen)
+- eine abweichende Dosis abhängig vom Wochentag anzugeben (in einer weiteren Dosage-Instanz).
 
 Es konkretisiert dabei nicht, zu welchem Zeitpunkt das Arzneimittel an dem betreffenden Wochentag anzuwenden ist.
 


### PR DESCRIPTION
This pull request refines the documentation for various timing schemes used in medication application. The changes improve clarity and consistency by restructuring sentences, adding details about dosage instances, and standardizing terminology across multiple files.

### Refinements to timing scheme documentation:

#### General clarifications:
* [`input/pagecontent/timing-interval-scheme.md`](diffhunk://#diff-cafac5067b9f552c0a5f89ad3228a2883944e9b0056ae0145b53a987d9af6266L3-R7): Added clarification that the schema does not specify exact application times (e.g., clock time, day time, or weekday).

#### Enhanced details about dosage and duration:
* [`input/pagecontent/timing-mman-scheme.md`](diffhunk://#diff-66e2db7161ccc707248b126cdaf856bf350b73eec4063fae65929f4920d79d8bR5-R9): Improved description by specifying that a varying dose dependent on the time of day can be defined in an additional dosage instance, and standardized phrasing for limiting the planned duration of application.
* [`input/pagecontent/timing-timeofday-scheme.md`](diffhunk://#diff-f908a4a89828e3c3fa23f7d39a2b0e1c1a0568dfd849603b603bb7693e2132b3L6-R7): Clarified that a varying dose dependent on the exact time can be defined in an additional dosage instance, and standardized phrasing for limiting the planned duration of application.
* [`input/pagecontent/timing-weekday-scheme.md`](diffhunk://#diff-52a4b5cc7f4b5ae8d25805a288262a5d5b45258a5c719cd7e4127fbc05deb868L6-R7): Enhanced explanation by specifying that a varying dose dependent on the weekday can be defined in an additional dosage instance, and standardized phrasing for limiting the planned duration of application.