### PR TITLE
refactor: update dosage and timing expressions for consistency

### DIFF
--- a/input/fsh/datatypes/dosage_dgmp.fsh
+++ b/input/fsh/datatypes/dosage_dgmp.fsh
@@ -62,6 +62,6 @@ Invariant: DosageDoseUnitSameCode
 Description: "Die Dosiereinheit muss über alle Dosierungen gleich sein."
 Expression: "(%resource.ofType(MedicationRequest).dosageInstruction | ofType(MedicationDispense).dosageInstruction | ofType(MedicationStatement).dosage).all(
 doseAndRate.exists() implies
-  %resource.dosageInstruction.doseAndRate.doseQuantity.code.distinct().count() = 1
+  %resource.dosageInstruction.doseAndRate.dose.ofType(Quantity).code.distinct().count() = 1
 )"
 Severity: #error

--- a/input/fsh/datatypes/timing_de_dgmp.fsh
+++ b/input/fsh/datatypes/timing_de_dgmp.fsh
@@ -219,22 +219,22 @@ Expression: "(
     ( /* only one different value and code are allowed*/
       (%resource.ofType(MedicationRequest).exists() or %resource.ofType(MedicationDispense).exists())
       implies
-      %resource.dosageInstruction.timing.repeat.boundsDuration.exists().not() or
+      %resource.dosageInstruction.timing.repeat.bounds.ofType(Duration).exists().not() or
       (
-        (%resource.dosageInstruction.timing.repeat.boundsDuration.value.distinct().count() = 1)
+        (%resource.dosageInstruction.timing.repeat.bounds.ofType(Duration).value.distinct().count() = 1)
         and
-        (%resource.dosageInstruction.timing.repeat.boundsDuration.code.distinct().count() = 1)
+        (%resource.dosageInstruction.timing.repeat.bounds.ofType(Duration).code.distinct().count() = 1)
       )
     )
     and
     (
       %resource.ofType(MedicationStatement).exists()
       implies
-      %resource.dosage.timing.repeat.boundsDuration.exists().not() or
+      %resource.dosage.timing.repeat.bounds.ofType(Duration).exists().not() or
       (
-        (%resource.dosage.timing.repeat.boundsDuration.value.distinct().count() = 1)
+        (%resource.dosage.timing.repeat.bounds.ofType(Duration).value.distinct().count() = 1)
         and
-        (%resource.dosage.timing.repeat.boundsDuration.code.distinct().count() = 1)
+        (%resource.dosage.timing.repeat.bounds.ofType(Duration).code.distinct().count() = 1)
       )
     )
   )


### PR DESCRIPTION
This pull request includes updates to FHIR Shorthand (FSH) expressions in two files to improve the accuracy and consistency of type handling for `Quantity` and `Duration` elements. The changes ensure that the correct type is explicitly specified in the expressions.

Updates to `dosage_dgmp.fsh`:

* Modified the `Invariant: DosageDoseUnitSameCode` expression to explicitly use `dose.ofType(Quantity)` instead of `doseQuantity` for type clarity and correctness.

Updates to `timing_de_dgmp.fsh`:

* Updated multiple expressions to replace `boundsDuration` with `bounds.ofType(Duration)` for improved type specificity. This change affects checks for the existence, distinct values, and distinct codes of `Duration` elements.