### PR TITLE
refactor: add comments to clarify cardinality and data type restrictions in dosage and timing profiles

### DIFF
--- a/input/fsh/datatypes/dosage_de.fsh
+++ b/input/fsh/datatypes/dosage_de.fsh
@@ -5,7 +5,7 @@ Parent: Dosage
 Id: DosageDE
 Title: "Dosage für deutschlandweite Nutzung"
 Description: "Gibt an, wie das Medikament vom Patienten eingenommen wird/wurde oder eingenommen werden soll."
-* extension contains GeneratedDosageInstructions named generatedDosageInstructions 0..1 MS
+* extension contains GeneratedDosageInstructionsEx named generatedDosageInstructions 0..1 MS
 * text 0..1 MS
   * ^short = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'"
   * ^definition = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"

--- a/input/fsh/datatypes/dosage_dgmp.fsh
+++ b/input/fsh/datatypes/dosage_dgmp.fsh
@@ -8,33 +8,45 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
 * obeys DosageDoseUnitSameCode
 
 * extension[generatedDosageInstructions]
-  * extension[algorithm]
-    * valueCoding 1..1 MS // The algorithm used to generate the text
+  * extension[algorithm] 1..
+    * valueCoding  // The algorithm used to generate the text
       * ^patternCoding.system = Canonical(DosageTextAlgorithmsCS)
       * ^patternCoding.code = #GermanDosageTextGenerator
       * version 1..1 MS
 * timing only TimingDgMP
 * doseAndRate 0..1 // Nur eine Dosierung für eine Medikation erlauben
+  * ^comment = "Begründung Einschränkung Kardinalität: Nur eine Dosierung pro Medikation ist in der ersten Ausbaustufe des dgMP vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * type 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Eine 'type'-Angabe ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * dose[x] only SimpleQuantity
+    * ^comment = "Begründung Einschränkung Datentyp: Nur einfache Mengenangaben sind in der ersten Ausbaustufe des dgMP vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * doseQuantity
   * doseQuantity from $kbv-dosiereinheit-vs
     * system 1..1 MS
     * code 1..1 MS
     * unit 1..1 MS
   * rate[x] 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Eine Verabreichungsmenge pro Zeiteinheit ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 
 // Remove unused Fields
 * sequence 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine Dosier-Sequenz ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * additionalInstruction 0..0
 * patientInstruction 0..0
 * asNeeded[x] 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine Bedarfsdosis ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * site 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine Verabreichungsstelle ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * route 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Ein Verabreichungsweg ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * method 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine Verabreichungsmethode ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * maxDosePerPeriod 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine maximale Dosis pro Zeitraum ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * maxDosePerAdministration 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine maximale Dosis pro Verabreichung ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * maxDosePerLifetime 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Eine maximale Dosis über die Lebenszeit ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 
 Invariant: DosageStructuredOrFreeText
 Description: "Die Dosierungsangabe darf entweder nur als Freitext oder nur als vollständige strukturierte Information erfolgen — eine Mischung ist nicht erlaubt."

--- a/input/fsh/datatypes/timing_de_dgmp.fsh
+++ b/input/fsh/datatypes/timing_de_dgmp.fsh
@@ -4,8 +4,9 @@ Id: TimingDgMP
 Title: "Zeitmuster für Dosierungen im dgMP"
 Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne werden verwendet, um festzuhalten, wann etwas geplant, erwartet oder angefordert ist. Die häufigste Anwendung ist in Dosierungsanweisungen für Medikamente. Sie werden aber auch für die Planung verschiedener Versorgungsleistungen genutzt und können zur Dokumentation von bereits erfolgten oder laufenden Aktivitäten verwendet werden."
 * event 0..0
+  * ^comment = "Begründung Einschränkung Kardinalität: Der Zeitpunkt des Ereignisses ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * code 0..0
-
+  * ^comment = "Begründung Einschränkung Kardinalität: Ein Timing-Code ist in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen. Stattdessen muss das Zeitmuster explizit strukturiert angegeben werden."
 * repeat 1..1 MS
   * obeys TimingOnlyOneType
   * obeys TimingIntervalOnlyOneFrequency
@@ -17,12 +18,12 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * obeys TimingOnlyOneBounds
   * bounds[x] MS
   * bounds[x] only Duration
+    * ^comment = "Begründung Einschränkung Datentyp: Nur eine Angabe zur Dauer ist in der ersten Ausbaustufe des dgMP vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * boundsDuration MS
   * boundsDuration.code 1..1 MS
   * boundsDuration.system 1..1 MS
   * boundsDuration.unit 1..1 MS
   * boundsDuration.code from DurationUnitsOfTimeDgMPVS (required)
-
   * frequency MS
   * period MS
   * periodUnit MS
@@ -34,15 +35,23 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
 
   // Restrict all elements in the repeat backbone to 0..0
   * count 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Wiederholungen sind in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * countMax 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Maximale Wiederholungen sind in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * duration 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Angaben zur Dauer einer Einzelgabe sind in der ersten Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * durationMax 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Angaben zur maximalen Dauer einer Einzelgabe sind in der ersten Ausbaustufe desdgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * durationUnit 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Angaben zur Einheit der Dauer einer Einzelgabe sind in der ersten Ausbaustufe desdgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * frequencyMax 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Eine maximale Frequenz ist in der ersten Ausbaustufe des dgMP nicht vorgesehen – es wird immer eine Frequenz explizit gesetzt, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * periodMax 0..0
+    * ^comment = "Begründung Einschränkung Kardinalität: Eine maximale Periodendauer ist in der ersten Ausbaustufe des dgMP nicht vorgesehen – es wird immer eine Dauer explizit gesetzt, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * offset 0..0
+    * ^short = "Zeitversatz"
+    * ^comment = "Begründung Einschränkung Kardinalität: Ein Zeitversatz ist in der ersten Ausbaustufe desdgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 
-//TODO Invariant info auf Teile der Invariante.
 Invariant: TimingOnlyOneType
 Description: "Only one kind of Timing is allowed. Current allowed timings: 4-Scheme, TimeOfDay, DayOfWeek, Interval, DayOfWeek and Time/4-Schema, Interval and Time/4-Schema"
 Expression: "( /* 4-Schema */

--- a/input/fsh/extensions/dosage-generated-dosage-instructions.fsh
+++ b/input/fsh/extensions/dosage-generated-dosage-instructions.fsh
@@ -5,7 +5,7 @@ Description: "Diese Extension enthält die automatisch generierte textuelle Dosi
 Context: Dosage
 * extension contains 
   text 1..1 MS and
-  algorithm 1..1 MS
+  algorithm 0..1 MS
 * extension[text]
   * valueString 1.. MS
 * extension[algorithm]


### PR DESCRIPTION
This pull request introduces changes to several FHIR Shorthand (FSH) files to refine dosage and timing definitions for the German Medication Plan (dgMP). The updates focus on simplifying cardinalities, adjusting extensions, and reducing complexity to improve clarity and usability in the initial implementation phase of the dgMP.

### Dosage Updates:
* Updated the extension name from `GeneratedDosageInstructions` to `GeneratedDosageInstructionsEx` in `input/fsh/datatypes/dosage_de.fsh` to reflect a new version or extended functionality.
* Adjusted the cardinality of the `algorithm` extension in `input/fsh/extensions/dosage-generated-dosage-instructions.fsh`, changing it from mandatory (`1..1`) to optional (`0..1`).

### dgMP-Specific Simplifications:
* Added comments explaining cardinality restrictions in `input/fsh/datatypes/dosage_dgmp.fsh` to limit complexity in the initial dgMP rollout. Examples include restricting `doseAndRate` to a single dosage, disallowing `type`, and excluding elements like `site`, `route`, and `method`.

### Timing Definitions:
* Restricted cardinalities for `event` and `code` in `input/fsh/datatypes/timing_de_dgmp.fsh`, with comments clarifying that these are excluded to simplify the initial dgMP implementation.
* Limited repeat-related elements (`count`, `duration`, `frequencyMax`, etc.) to `0..0` in `input/fsh/datatypes/timing_de_dgmp.fsh`, with comments explaining that these restrictions aim to reduce complexity for the dgMP's first phase.