### PR TITLE
refactor: update titles and descriptions for dosage and timing profiles

### DIFF
--- a/input/fsh/datatypes/dosage_de.fsh
+++ b/input/fsh/datatypes/dosage_de.fsh
@@ -3,8 +3,8 @@
 Profile: DosageDE
 Parent: Dosage
 Id: DosageDE
-Title: "Dosage für deutschlandweite Nutzung"
-Description: "Gibt an, wie das Medikament vom Patienten eingenommen wird/wurde oder eingenommen werden soll."
+Title: "Dosage DE"
+Description: "Gibt an, wie das Medikament eingenommen oder verabreicht wurde bzw. eingenommen oder verabreicht werden soll – entweder selbst vom Patienten eingenommen oder bei Fremdverabreichung von Dritten (z. B. Leistungserbringer, Angehörige) verabreicht."
 * extension contains GeneratedDosageInstructions named generatedDosageInstructions 0..1 MS
 * text 0..1 MS
   * ^short = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'"

--- a/input/fsh/datatypes/dosage_dgmp.fsh
+++ b/input/fsh/datatypes/dosage_dgmp.fsh
@@ -1,7 +1,7 @@
 Profile: DosageDgMP
 Parent: DosageDE
 Id: DosageDgMP
-Title: "Dosage für dgMP"
+Title: "Dosage dgMP"
 Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenommen wird/wurde oder eingenommen werden soll."
 * obeys DosageStructuredOrFreeText
 * obeys DosageStructuredRequiresBoth

--- a/input/fsh/datatypes/timing_de.fsh
+++ b/input/fsh/datatypes/timing_de.fsh
@@ -1,7 +1,7 @@
 Profile: TimingDE
 Parent: Timing
 Id: TimingDE
-Title: "Zeitmuster für deutschlandweite Dosierungen"
+Title: "Timing DE"
 Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne werden verwendet, um festzuhalten, wann etwas geplant, erwartet oder angefordert ist. Die häufigste Anwendung ist in Dosierungsanweisungen für Medikamente. Sie werden aber auch für die Planung verschiedener Versorgungsleistungen genutzt und können zur Dokumentation von bereits erfolgten oder laufenden Aktivitäten verwendet werden."
 * repeat MS
   * ^short = "Wann das Ereignis stattfinden soll"

--- a/input/fsh/datatypes/timing_de_dgmp.fsh
+++ b/input/fsh/datatypes/timing_de_dgmp.fsh
@@ -1,7 +1,7 @@
 Profile: TimingDgMP
 Parent: TimingDE
 Id: TimingDgMP
-Title: "Zeitmuster für Dosierungen im dgMP"
+Title: "Timing dgMP"
 Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne werden verwendet, um festzuhalten, wann etwas geplant, erwartet oder angefordert ist. Die häufigste Anwendung ist in Dosierungsanweisungen für Medikamente. Sie werden aber auch für die Planung verschiedener Versorgungsleistungen genutzt und können zur Dokumentation von bereits erfolgten oder laufenden Aktivitäten verwendet werden."
 * event 0..0
 * code 0..0

--- a/input/fsh/extensions/dosage-generated-dosage-instructions.fsh
+++ b/input/fsh/extensions/dosage-generated-dosage-instructions.fsh
@@ -1,6 +1,6 @@
 Extension: GeneratedDosageInstructionsEx
 Id: GeneratedDosageInstructions
-Title: "Maschinell erzeugte Dosieranweisung"
+Title: "Generated Dosage Instructions"
 Description: "Diese Extension enthält die automatisch generierte textuelle Dosierungsanweisung, die auf Basis der bereitgestellten strukturierten Dosierungsinformationen erstellt wurde."
 Context: Dosage
 * extension contains 

--- a/input/fsh/profiles/medicationDispense_profile.fsh
+++ b/input/fsh/profiles/medicationDispense_profile.fsh
@@ -1,8 +1,8 @@
 Profile: MedicationDispenseDgMP
 Parent: MedicationDispense
 Id: MedicationDispenseDgMP
-Title: "MedicationDispense zur Nutzung von Dosierungen für dgMP"
-Description: "Dieses Profil enthält eine Referenz der dosageInstruction auf das Dosierungsprofil für den Kontext dgMP"
+Title: "Medication Dispense dgMP"
+Description: "Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht. Stattdessen sollte das jeweils passende Dosage-Profil direkt in das eigene Profil eingebunden werden."
 * ^abstract = true
 * dosageInstruction only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"

--- a/input/fsh/profiles/medicationStatement_profile.fsh
+++ b/input/fsh/profiles/medicationStatement_profile.fsh
@@ -1,8 +1,8 @@
 Profile: MedicationStatementDgMP
 Parent: MedicationStatement
 Id: MedicationStatementDgMP
-Title: "MedicationStatement zur Nutzung von Dosierungen für dgMP"
-Description: "Dieses Profil enthält eine Referenz der dosage auf das Dosierungsprofil für den Kontext dgMP"
+Title: "Medication Statement dgMP"
+Description: "Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht. Stattdessen sollte das jeweils passende Dosage-Profil direkt in das eigene Profil eingebunden werden."
 * ^abstract = true
 * dosage only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"

--- a/input/fsh/profiles/medication_request_profile.fsh
+++ b/input/fsh/profiles/medication_request_profile.fsh
@@ -1,8 +1,8 @@
 Profile: MedicationRequestDgMP
 Parent: MedicationRequest
 Id: MedicationRequestDgMP
-Title: "MedicationRequest zur Nutzung von Dosierungen für dgMP"
-Description: "Dieses Profil enthält eine Referenz der dosageInstruction auf das Dosierungsprofil für den Kontext dgMP"
+Title: "Medication Request dgMP"
+Description: "Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht. Stattdessen sollte das jeweils passende Dosage-Profil direkt in das eigene Profil eingebunden werden."
 * ^abstract = true
 * dosageInstruction only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"

--- a/input/fsh/terminologies/DosageDoseQuantity-VS.fsh
+++ b/input/fsh/terminologies/DosageDoseQuantity-VS.fsh
@@ -1,6 +1,6 @@
 ValueSet: DosageDoseQuantityDEVS
 Id: DosageDoseQuantityDE
-Title: "Dosage Dose-Quantity ValueSet"
+Title: "Dosage DoseQuantity ValueSet"
 Description: "Diese ValueSet enthält Konzepte für die Dosierungseinheit in der Dosiermenge."
 * include codes from system $kbv-dosiereinheit
 * include codes from system $ucum

--- a/input/fsh/terminologies/DurationUnitsOfTimeDgMP-VS.fsh
+++ b/input/fsh/terminologies/DurationUnitsOfTimeDgMP-VS.fsh
@@ -1,6 +1,6 @@
 ValueSet: DurationUnitsOfTimeDgMPVS
 Id: DosageUnitsOfTimeDgMP
-Title: "Zeiteinheiten für die DurationUnit in Dosierungen im dgMP"
+Title: "Duration UnitsOfTime dgMP ValueSet"
 Description: "Dieses ValueSet enthält dgMPV DurationUnit Zeiteinheiten aus dem UCUM-CodeSystem in deutscher Übersetzung"
 * include $ucum#d 
   * ^designation.language = #de-DE

--- a/input/fsh/terminologies/EDQMUnitOfPresentation-VS.fsh
+++ b/input/fsh/terminologies/EDQMUnitOfPresentation-VS.fsh
@@ -2,7 +2,7 @@
 //TODO: Übersetzungen der Codes und VS bei bfarm anfragen
 ValueSet: EDQMUnitOfPresentationVS
 Id: EDQMUnitOfPresentation
-Title: "EDQM Unit of Presentation"
+Title: "EDQM Unit of Presentation ValueSet"
 Description: "ValueSet Einheit der Darreichungsform gemäß EDQM, UOP, siehe https://standardterms.edqm.eu/#"
 * ^experimental = true
 * $edqm#15001000 "Actuation"

--- a/input/fsh/terminologies/PeriodUnitsOfTimeDgMP-VS.fsh
+++ b/input/fsh/terminologies/PeriodUnitsOfTimeDgMP-VS.fsh
@@ -1,6 +1,6 @@
 ValueSet: PeriodUnitsOfTimeDgMPVS
 Id: PeriodUnitsOfTimeDgMP
-Title: "Zeiteinheiten für PeriodUnit in Dosierungen im dgMP"
+Title: "Period UnitsOfTime dgMP ValueSet"
 Description: "Dieses ValueSet enthält dgMPV PeriodUnit Zeiteinheiten aus dem UCUM-CodeSystem in deutscher Übersetzung"
 * include $ucum#d 
   * ^designation.language = #de-DE

--- a/input/fsh/terminologies/de_dgmp_event_timing_vs.fsh
+++ b/input/fsh/terminologies/de_dgmp_event_timing_vs.fsh
@@ -1,6 +1,6 @@
 ValueSet: TimingWhenDgMPVS
 Id: TimingWhenDgMP
-Title: "TimingWhenDgMP"
+Title: "Timing When dgMP"
 Description: "Tageszeiten für Zeitmuster"
 * $cs-event-timing#MORN
 * $cs-event-timing#NOON

--- a/input/fsh/terminologies/dosage_text_algorithm.fsh
+++ b/input/fsh/terminologies/dosage_text_algorithm.fsh
@@ -1,11 +1,11 @@
 CodeSystem: DosageTextAlgorithmsCS
 Id: DosageTextAlgorithms
-Title: "Algorithmen für Textgenerierung von Dosierungen"
+Title: "Dosage Text Algorithms CodeSystem"
 Description: "Dieses CodeSystem legt die Algorithmen fest, mit denen aus strukturierten Dosierungsangaben automatisch Dosierungsanweisungen in Textform erzeugt werden."
 * #GermanDosageTextGenerator "German Dosage Text Generator" "Source: https://github.com/hl7germany/medication-ig-de-r4/blob/develop/input/content/dosage-to-text.py"
 
 ValueSet: DosageTextAlgorithmsVS
 Id: DosageTextAlgorithms
-Title: "Algorithmen für Textgenerierung von Dosierungen"
+Title: "Dosage Text Algorithms ValueSet"
 Description: "Dieses ValueSet legt die Algorithmen fest, mit denen aus strukturierten Dosierungsangaben automatisch Dosierungsanweisungen in Textform erzeugt werden."
 * include codes from system DosageTextAlgorithmsCS


### PR DESCRIPTION
This pull request primarily focuses on standardizing and simplifying titles and descriptions across various profiles, extensions, and terminologies in the `input/fsh` directory. It also includes updates to improve clarity and consistency in naming conventions. Below are the most significant changes grouped by theme:

### Updates to Profiles and Extensions:
* [`input/fsh/datatypes/dosage_de.fsh`](diffhunk://#diff-3ce49227a5453fc16752613d2f1db224c0d0eb0f5e5ac0532a09dba3dbfcbb83L6-R7): Updated the title to "Dosage DE" and expanded the description to clarify scenarios of self-administration and third-party administration.
* [`input/fsh/extensions/dosage-generated-dosage-instructions.fsh`](diffhunk://#diff-6ae97f241f695b750b1ad3f5ba445542b68ec60e97585982d6602c8d4e410e3aL3-R3): Changed the title to "Generated Dosage Instructions" for better alignment with naming conventions.

### Updates to Medication-related Profiles:
* [`input/fsh/profiles/medicationDispense_profile.fsh`](diffhunk://#diff-31aa1a3561f3402a7f0bf2d54b1567f2d4de765048075c10c89cf3eb6e39e7caL4-R5): Revised the title to "Medication Dispense dgMP" and updated the description to indicate that the profile is for validation purposes only, not for productive use.
* [`input/fsh/profiles/medicationStatement_profile.fsh`](diffhunk://#diff-d26e6cd737ba8a0a61389f9c61a57dfac5fd3c3b3b33b4077b88bacfd5276443L4-R5): Changed the title to "Medication Statement dgMP" and adjusted the description to match the validation-only purpose.
* [`input/fsh/profiles/medication_request_profile.fsh`](diffhunk://#diff-cf846cc07651cb67e1822e9623c5517bc0d92583eca58361ca457accf28880aeL4-R5): Updated the title to "Medication Request dgMP" and clarified the description to emphasize its validation role.

### Updates to Terminologies:
* [`input/fsh/terminologies/DosageDoseQuantity-VS.fsh`](diffhunk://#diff-df35b421e0345f47e9a664e3f4414c907b741903b22c492eee3ae912e0a92900L3-R3): Simplified the title to "Dosage DoseQuantity ValueSet" for consistency.
* [`input/fsh/terminologies/dosage_text_algorithm.fsh`](diffhunk://#diff-f9abeb067e98e3ad1ce2579ce3bfc3a63027760446a7cde5295679e5a94e6af7L3-R9): Renamed titles to "Dosage Text Algorithms CodeSystem" and "Dosage Text Algorithms ValueSet" for improved clarity and alignment.

These changes ensure consistency in naming conventions and improve the readability and usability of the profiles and terminologies.