### PR TITLE
docs: add introductory sections with dragons for Medication Dispense,  Request, and Statement profiles

### DIFF
--- a/input/pagecontent/StructureDefinition-MedicationDispenseDgMP-intro.md
+++ b/input/pagecontent/StructureDefinition-MedicationDispenseDgMP-intro.md
@@ -1,0 +1,5 @@
+## Verwendung
+
+<div class="dragon">
+Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht
+</div>

--- a/input/pagecontent/StructureDefinition-MedicationRequestDgMP-intro.md
+++ b/input/pagecontent/StructureDefinition-MedicationRequestDgMP-intro.md
@@ -1,0 +1,5 @@
+## Verwendung
+
+<div class="dragon">
+Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht
+</div>

--- a/input/pagecontent/StructureDefinition-MedicationStatementDgMP-intro.md
+++ b/input/pagecontent/StructureDefinition-MedicationStatementDgMP-intro.md
@@ -1,0 +1,5 @@
+## Verwendung
+
+<div class="dragon">
+Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht
+</div>


### PR DESCRIPTION
This pull request adds a usage section to multiple `StructureDefinition` introduction files to clarify the purpose of the profiles. The new section explicitly states that these profiles are intended solely for validation within the Implementation Guide and are not meant for productive use.

Documentation updates:

* [`input/pagecontent/StructureDefinition-MedicationDispenseDgMP-intro.md`](diffhunk://#diff-3342035d20dedfba5cefbd30ee30679eafe0cef8c95f6f8a85ccb9ee6ef951caR1-R5): Added a "Verwendung" section with a note specifying the profile's validation-only purpose.
* [`input/pagecontent/StructureDefinition-MedicationRequestDgMP-intro.md`](diffhunk://#diff-3342035d20dedfba5cefbd30ee30679eafe0cef8c95f6f8a85ccb9ee6ef951caR1-R5): Added a "Verwendung" section with a note specifying the profile's validation-only purpose.
* [`input/pagecontent/StructureDefinition-MedicationStatementDgMP-intro.md`](diffhunk://#diff-3342035d20dedfba5cefbd30ee30679eafe0cef8c95f6f8a85ccb9ee6ef951caR1-R5): Added a "Verwendung" section with a note specifying the profile's validation-only purpose.