### PR TITLE
Improve-script

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -3,45 +3,54 @@ import json
 import sys
 import os
 
+__version__ = "1.0.0"
+
 class GermanDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
+        
         elements = []
-        # Check for unsupported features
+    # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
         if unsupported_fields:
             felder = ", ".join(unsupported_fields)
             return f"Die Dosiskonfiguration mit den Feldern {felder} wird in der aktuellen Ausbaustufe nicht unterstützt."
         
-        # Frequency
+    # Rückgabe der Freitextdosierung, falls vorhanden
+        freeText = dosage.get('text', {})
+        if freeText:
+            return freeText
+        
+    # 1. Bestimmen des Zeitabschnitts
+        # a) Frequency
         frequency = self.get_frequency(dosage)
         if frequency:
             elements.append(frequency)
-        # Days of week
+        # b) Days of week
         days_of_week = self.get_days_of_week(dosage)
         if days_of_week:
             elements.append(days_of_week)
-         # Wenn weder frequency noch days_of_week gesetzt sind, "täglich" einfügen
+         # c) Wenn weder frequency noch days_of_week gesetzt sind, "täglich" einfügen
         if not frequency and not days_of_week:
             elements.append("täglich")
-        # Dose
+    # 2. Dosis
         dose = self.get_dose(dosage)
         if dose:
             elements.append(dose)
-        # Times of day
+    # 3. Geplante Frequenz innerhalb des Zeitabschnitts
+        # a) Times of day
         times_of_day = self.get_times_of_day(dosage)
         if times_of_day:
             elements.append(times_of_day)
-        # When/offset
-        when_and_offset = self.get_when_and_offset(dosage)
-        if when_and_offset:
-            elements.append(when_and_offset)
-        # Duration
+        # b) When
+        when = self.get_when(dosage)
+        if when:
+            elements.append(when)
+        
+    # 4. Gesamtdauer der Anwendung
         bounds = self.get_bounds(dosage)
         if bounds:
             elements.append(bounds)
-        # Free text
-        if dosage.get('text'):
-            elements.append(dosage['text'])
+
         return " — ".join(elements)
     
     def get_unsupported_fields(self, dosage):
@@ -51,7 +60,7 @@ class GermanDosageTextGenerator:
         }
         deny_timing_fields = {"event"}
         deny_timing_repeat_fields = {
-            "count", "countMax", "boundsPeriod", "boundsRange", "offset"
+            "count", "countMax", "boundsPeriod", "boundsRange", "offset", "frequencyMax", "periodMax"
         }
         deny_doseAndRate_subfields = {"doseRange", "rateQuantity", "rateRange", "rateRatio"}
 
@@ -80,7 +89,6 @@ class GermanDosageTextGenerator:
             
         return list(unsupported)
 
-
     def get_dose(self, dosage):
         dose_and_rate = dosage.get('doseAndRate', [])
         if not dose_and_rate:
@@ -96,9 +104,7 @@ class GermanDosageTextGenerator:
         if not repeat:
             return ""
         frequency = repeat.get('frequency')
-        frequency_max = repeat.get('frequencyMax')
         period = repeat.get('period')
-        period_max = repeat.get('periodMax')
         period_unit = repeat.get('periodUnit')
         if frequency is None and period is None and period_unit is None:
             return ""
@@ -111,8 +117,6 @@ class GermanDosageTextGenerator:
                 return "dreimal täglich"
             elif frequency == 4:
                 return "viermal täglich"
-            elif frequency_max:
-                return f"{frequency}-{frequency_max}mal täglich"
             else:
                 return f"{frequency}mal täglich"
         if period_unit == 'wk' and period == 1:
@@ -120,15 +124,13 @@ class GermanDosageTextGenerator:
                 return "einmal wöchentlich"
             elif frequency == 2:
                 return "zweimal wöchentlich"
-            elif frequency_max:
-                return f"{frequency}-{frequency_max}mal wöchentlich"
             else:
                 return f"{frequency}mal wöchentlich"
         if frequency == 1:
-            period_text = self.format_period_unit(period, period_max, period_unit)
+            period_text = self.format_period_unit(period, period_unit)
             return f"alle {period_text}"
-        freq_text = f"{frequency}-{frequency_max}mal" if frequency_max and frequency_max != frequency else f"{frequency}mal"
-        period_text = self.format_period_unit(period, period_max, period_unit)
+        freq_text = f"{frequency}mal"
+        period_text = self.format_period_unit(period, period_unit)
         return f"{freq_text} pro {period_text}"
 
     def get_days_of_week(self, dosage):
@@ -150,7 +152,7 @@ class GermanDosageTextGenerator:
         return "um " + ", ".join([self.format_time(time) for time in sorted_times])
 
 
-    def get_when_and_offset(self, dosage):
+    def get_when(self, dosage):
         timing = dosage.get('timing', {})
         repeat = timing.get('repeat', {})
         parts = []
@@ -177,13 +179,11 @@ class GermanDosageTextGenerator:
             return f"für {dur}" if dur else ""
         return ""
 
-
     def format_quantity(self, quantity, with_je=True):
         value = quantity.get('value', 0)
         unit = quantity.get('unit') or quantity.get('code') or ""
         prefix = "je " if with_je else ""
         return f"{prefix}{value}{' ' + unit if unit else ''}"
-
 
     def format_time(self, time):
         try:
@@ -217,10 +217,8 @@ class GermanDosageTextGenerator:
         units_name = multi_units.get(unit, unit)
         return unit_name if value == 1 else f"{units_name}"
 
-    def format_period_unit(self, period, period_max, unit):
+    def format_period_unit(self, period, unit):
         unit_text = self.format_time_unit(period, unit)
-        if period_max and period_max != period:
-            return f"{period}-{period_max} {unit_text}"
         return f"{period} {unit_text}"
 
     def format_days_of_week(self, days):
@@ -257,16 +255,6 @@ class GermanDosageTextGenerator:
         }
         return when_codes.get(when.upper(), when)
     
-    def is_only_key_and_bounds(self, repeat, key):
-        allowed = {key}
-        # boundsDuration, boundsRange, boundsPeriod sind erlaubt
-        allowed.update([k for k in repeat if k.startswith('bounds')])
-        # Gibt es noch andere Schlüssel mit Wert?
-        for k, v in repeat.items():
-            if k not in allowed and v:
-                return False
-        return key in repeat and repeat[key]
-
 def main():
     if len(sys.argv) < 2:
         print('Verwendung: python dosage-generator.py <dosage.json>', file=sys.stderr)

--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -7,7 +7,7 @@ __version__ = "1.0.0"
 
 class GermanDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
-        
+
         elements = []
     # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
@@ -15,11 +15,10 @@ class GermanDosageTextGenerator:
             felder = ", ".join(unsupported_fields)
             return f"Die Dosiskonfiguration mit den Feldern {felder} wird in der aktuellen Ausbaustufe nicht unterstützt."
         
-    # Rückgabe der Freitextdosierung, falls vorhanden
-        freeText = dosage.get('text', {})
-        if freeText:
-            return freeText
-        
+        # If free-text override is present, return empty string
+        if dosage.get('text'):
+            return ""
+
     # 1. Bestimmen des Zeitabschnitts
         # a) Frequency
         frequency = self.get_frequency(dosage)
@@ -45,12 +44,11 @@ class GermanDosageTextGenerator:
         when = self.get_when(dosage)
         if when:
             elements.append(when)
-        
+
     # 4. Gesamtdauer der Anwendung
         bounds = self.get_bounds(dosage)
         if bounds:
             elements.append(bounds)
-
         return " — ".join(elements)
     
     def get_unsupported_fields(self, dosage):
@@ -254,7 +252,7 @@ class GermanDosageTextGenerator:
             'NIGHT': 'nachts'
         }
         return when_codes.get(when.upper(), when)
-    
+
 def main():
     if len(sys.argv) < 2:
         print('Verwendung: python dosage-generator.py <dosage.json>', file=sys.stderr)

--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -49,6 +49,7 @@ class GermanDosageTextGenerator:
         bounds = self.get_bounds(dosage)
         if bounds:
             elements.append(bounds)
+
         return " — ".join(elements)
     
     def get_unsupported_fields(self, dosage):

--- a/input/includes/supported-dosage-examples.md
+++ b/input/includes/supported-dosage-examples.md
@@ -11,7 +11,7 @@
 |[MedicationRequest-Example-MR-Dosage-UnitStueck-1020](./MedicationRequest-Example-MR-Dosage-UnitStueck-1020.html) | täglich — je 1 Stück — morgens<br><br>täglich — je 2 Stück — abends |
 |[MedicationRequest-Example-MR-Dosage-comb-dayofweek-2](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-2.html) | Montag und Freitag — je 1 Stück — morgens und abends<br><br>Dienstag und Samstag — je 2 Stück — morgens und abends |
 |[MedicationRequest-Example-MR-Dosage-10120](./MedicationRequest-Example-MR-Dosage-10120.html) | täglich — je 1 Stück — morgens<br><br>täglich — je 0.5 Stück — abends |
-|[MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) | 2 Tabletten morgens zum Frühstück |
+|[MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) |  |
 |[MedicationRequest-Example-MR-Dosage-comb-dayofweek-3](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-3.html) | Montag und Freitag — je 1 Stück — morgens — für 3 Woche(n)<br><br>Montag und Freitag — je 2 Stück — mittags — für 3 Woche(n) |
 |[MedicationRequest-Example-MR-Dosage-1010-10-Days](./MedicationRequest-Example-MR-Dosage-1010-10-Days.html) | täglich — je 1 Stück — morgens und abends — für 10 Woche(n) |
 |[MedicationRequest-Example-MR-Dosage-tod-2-12am](./MedicationRequest-Example-MR-Dosage-tod-2-12am.html) | täglich — je 2 Stück — um 12:00 Uhr |

--- a/input/includes/supported-dosage-examples.md
+++ b/input/includes/supported-dosage-examples.md
@@ -11,7 +11,7 @@
 |[MedicationRequest-Example-MR-Dosage-UnitStueck-1020](./MedicationRequest-Example-MR-Dosage-UnitStueck-1020.html) | täglich — je 1 Stück — morgens<br><br>täglich — je 2 Stück — abends |
 |[MedicationRequest-Example-MR-Dosage-comb-dayofweek-2](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-2.html) | Montag und Freitag — je 1 Stück — morgens und abends<br><br>Dienstag und Samstag — je 2 Stück — morgens und abends |
 |[MedicationRequest-Example-MR-Dosage-10120](./MedicationRequest-Example-MR-Dosage-10120.html) | täglich — je 1 Stück — morgens<br><br>täglich — je 0.5 Stück — abends |
-|[MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) | täglich — 2 Tabletten morgens zum Frühstück |
+|[MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) | 2 Tabletten morgens zum Frühstück |
 |[MedicationRequest-Example-MR-Dosage-comb-dayofweek-3](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-3.html) | Montag und Freitag — je 1 Stück — morgens — für 3 Woche(n)<br><br>Montag und Freitag — je 2 Stück — mittags — für 3 Woche(n) |
 |[MedicationRequest-Example-MR-Dosage-1010-10-Days](./MedicationRequest-Example-MR-Dosage-1010-10-Days.html) | täglich — je 1 Stück — morgens und abends — für 10 Woche(n) |
 |[MedicationRequest-Example-MR-Dosage-tod-2-12am](./MedicationRequest-Example-MR-Dosage-tod-2-12am.html) | täglich — je 2 Stück — um 12:00 Uhr |

--- a/input/pagecontent/dosage-to-text.md
+++ b/input/pagecontent/dosage-to-text.md
@@ -15,8 +15,8 @@ Für Informationen wie im dgMP sichergestellt wird, dass der Text an einer Dosie
 
 Das Skript unterstützt aktuell nur eine Teilmenge der möglichen Felder für Dosierungsangaben.  
 Nicht unterstützte Felder führen dazu, dass die Konfiguration als „nicht unterstützt“ zurückgewiesen wird. Die nicht unterstützten Felder werden explizit benannt.
+
 Die unterstützten Felder in Dosage sind:
-  - text
   - doseAndRate.doseQuantity
   - timing.repeat.boundsDuration
   - timing.repeat.frequency
@@ -33,6 +33,8 @@ Die Dosiskonfiguration mit den Feldern <Liste> wird derzeit nicht unterstützt. 
 
 Die Umwandlung der strukturierten Felder erfolgt nur, wenn ausschließlich unterstützte Felder verwendet werden.
 
+Freitext-Dosierungen mit einer Angabe in `.text` werden so dargestellt, dass der enthaltene Text ausgegeben wird.
+
 #### Versionierung des Algorithmus
 
 Die Aktuelle Version des Algortimus mit unterstützten Felder ist in der [Python Referenzimplementierung](./dosage-to-text.py) unter `__version__` angegeben und reflektiert die Version des IG's.
@@ -45,6 +47,7 @@ Die Reihenfolge der Komponenten entspricht der folgenden Logik:
   1. Zeitabschnitt  
      a) frequency UND period UND/ODER  
      b) dayOfWeek
+     c) falls kein Zeitabschnitt angegeben wird, wird "täglich" gesetzt
   2. Dosis (doseAndRate.doseQuantity)
   3. Geplante Frequenz innerhalb des Zeitabschnitts  
      a) timeOfDay  

--- a/input/pagecontent/dosage-to-text.md
+++ b/input/pagecontent/dosage-to-text.md
@@ -20,9 +20,7 @@ Die unterstützten Felder in Dosage sind:
   - doseAndRate.doseQuantity
   - timing.repeat.boundsDuration
   - timing.repeat.frequency
-  - timing.repeat.frequencyMax
   - timing.repeat.period
-  - timing.repeat.periodMax
   - timing.repeat.periodUnit
   - timing.repeat.dayOfWeek
   - timing.repeat.timeOfDay
@@ -83,4 +81,26 @@ und wird kontinuierlich weiterentwickelt.
 
 Hinweis:  
 Diese Seite beschreibt den aktuellen Stand der unterstützten Felder und die daraus resultierende Textgenerierung.  
-Für die vollständige Abdeckung aller FHIR-Dosierungsfelder ist eine schrittweise Erweiterung des Skripts vorgesehen. 
+Für die vollständige Abdeckung aller FHIR-Dosierungsfelder ist eine schrittweise Erweiterung des Skripts vorgesehen.
+
+### Übersetzungslogik
+
+Im folgenden wird für jedes Element ein Beispiel angegeben, wie die Überführung von strukturierter Angabe zu textueller Repräsentation aussieht.
+
+#### Dosage
+
+| Element                       | Darstellung (Deutsch)         | Beispiel(e)           |
+|-------------------------------|-------------------------------|-----------------------|
+| **doseAndRate.doseQuantity**  | `{value} {unit}`              | `50 Milligramm`<br>`2 Tabletten` |
+
+#### Timing
+
+| Element                | Darstellung (Deutsch)                    | Beispiel(e)                    |
+|------------------------|------------------------------------------|--------------------------------|
+| **repeat.boundsDuration** | `für {value} {unit}`                 | `für 7 Tage`                   |
+| **repeat.frequency**      | `{frequency} mal`<br>oder, wenn `period`/`periodUnit` gesetzt:<br>`{frequency} mal pro {period} {periodUnit}` | `3 mal täglich`<br>`2 mal pro Woche` |
+| **repeat.period**         | (falls `frequency` gesetzt)<br>`{frequency} mal alle {period} {periodUnit}` | `3 mal alle 8 Stunden`         |
+| **repeat.periodUnit**     | Zeit-Einheiten:<br>- `s` = Sekunden<br>- `min` = Minuten<br>- `h` = Stunden<br>- `d` = Tage<br>- `wk` = Wochen<br>- `mo` = Monate<br>- `a` = Jahre |                                |
+| **repeat.dayOfWeek**      | `am {dayOfWeek}`<br>Bei mehreren Tagen:<br>`am Montag, Mittwoch und Freitag`<br>(vollständige deutsche Wochentagsnamen verwenden) | `am Dienstag`<br>`am Montag, Mittwoch und Freitag` |
+| **repeat.timeOfDay**      | `um {timeOfDay}`<br>Bei mehreren Zeiten:<br>`um 10:00 und 15:00` | `um 8:00`<br>`um 10:00 und 15:00` |
+| **repeat.when**           | `{when}`<br>(z. B. `morgens`, `mittags`, `abends`, `nachts`)<br>Bei mehreren:<br>`morgens und abends` | `morgens`<br>`morgens und abends` |

--- a/input/pagecontent/dosage-to-text.md
+++ b/input/pagecontent/dosage-to-text.md
@@ -43,8 +43,8 @@ Die einzelnen Komponenten der Dosierungsanweisung werden durch „ — “ (Leer
 Die Reihenfolge der Komponenten entspricht der folgenden Logik:
 
   1. Zeitabschnitt  
-     a) frequency UND period UND/ODER  
-     b) dayOfWeek
+     a) frequency UND period UND/ODER 
+     b) dayOfWeek 
      c) falls kein Zeitabschnitt angegeben wird, wird "täglich" gesetzt
   2. Dosis (doseAndRate.doseQuantity)
   3. Geplante Frequenz innerhalb des Zeitabschnitts  

--- a/input/pagecontent/dosage-to-text.md
+++ b/input/pagecontent/dosage-to-text.md
@@ -31,8 +31,6 @@ Die Dosiskonfiguration mit den Feldern <Liste> wird derzeit nicht unterstützt. 
 
 Die Umwandlung der strukturierten Felder erfolgt nur, wenn ausschließlich unterstützte Felder verwendet werden.
 
-Freitext-Dosierungen mit einer Angabe in `.text` werden so dargestellt, dass der enthaltene Text ausgegeben wird.
-
 #### Versionierung des Algorithmus
 
 Die Aktuelle Version des Algortimus mit unterstützten Felder ist in der [Python Referenzimplementierung](./dosage-to-text.py) unter `__version__` angegeben und reflektiert die Version des IG's.

--- a/scripts/add-dosage-extension.py
+++ b/scripts/add-dosage-extension.py
@@ -33,20 +33,36 @@ def add_extension_to_medicationresource(file_path, dosage_text):
     # Handle MedicationRequest: dosageInstruction
     if "dosageInstruction" in data and data["dosageInstruction"]:
         for dosage in data["dosageInstruction"]:
+            # Filter existing extensions
             if "extension" in dosage:
-                dosage["extension"] = filter_extensions(dosage["extension"])
+                existing_exts = filter_extensions(dosage["extension"])
             else:
-                dosage["extension"] = []
-            dosage["extension"].append(extension)
+                existing_exts = []
+            # Only add the new extension if dosage_text is non-empty
+            if dosage_text:
+                existing_exts.append(extension)
+            # Only set the extension property if there's at least one extension
+            if existing_exts:
+                dosage["extension"] = existing_exts
+            else:
+                dosage.pop("extension", None)
 
     # Handle MedicationStatement: dosage
     if "dosage" in data and data["dosage"]:
         for dosage in data["dosage"]:
+            # Filter existing extensions
             if "extension" in dosage:
-                dosage["extension"] = filter_extensions(dosage["extension"])
+                existing_exts = filter_extensions(dosage["extension"])
             else:
-                dosage["extension"] = []
-            dosage["extension"].append(extension)
+                existing_exts = []
+            # Only add the new extension if dosage_text is non-empty
+            if dosage_text:
+                existing_exts.append(extension)
+            # Only set the extension property if there's at least one extension
+            if existing_exts:
+                dosage["extension"] = existing_exts
+            else:
+                dosage.pop("extension", None)
 
     # Overwrite the file (or write to a new file)
     with open(file_path, 'w', encoding='utf-8') as f:

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -7,7 +7,7 @@ __version__ = "1.0.0"
 
 class GermanDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
-        
+
         elements = []
     # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
@@ -15,11 +15,10 @@ class GermanDosageTextGenerator:
             felder = ", ".join(unsupported_fields)
             return f"Die Dosiskonfiguration mit den Feldern {felder} wird in der aktuellen Ausbaustufe nicht unterstützt."
         
-    # Rückgabe der Freitextdosierung, falls vorhanden
-        freeText = dosage.get('text', {})
-        if freeText:
-            return freeText
-        
+        # If free-text override is present, return empty string
+        if dosage.get('text'):
+            return ""
+
     # 1. Bestimmen des Zeitabschnitts
         # a) Frequency
         frequency = self.get_frequency(dosage)
@@ -45,7 +44,7 @@ class GermanDosageTextGenerator:
         when = self.get_when(dosage)
         if when:
             elements.append(when)
-        
+
     # 4. Gesamtdauer der Anwendung
         bounds = self.get_bounds(dosage)
         if bounds:
@@ -254,7 +253,7 @@ class GermanDosageTextGenerator:
             'NIGHT': 'nachts'
         }
         return when_codes.get(when.upper(), when)
-    
+
 def main():
     if len(sys.argv) < 2:
         print('Verwendung: python dosage-generator.py <dosage.json>', file=sys.stderr)

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -60,7 +60,7 @@ class GermanDosageTextGenerator:
         }
         deny_timing_fields = {"event"}
         deny_timing_repeat_fields = {
-            "count", "countMax", "boundsPeriod", "boundsRange", "offset"
+            "count", "countMax", "boundsPeriod", "boundsRange", "offset", "frequencyMax", "periodMax"
         }
         deny_doseAndRate_subfields = {"doseRange", "rateQuantity", "rateRange", "rateRatio"}
 


### PR DESCRIPTION
This pull request introduces significant updates to the `dosage-to-text.py` script and associated documentation to improve dosage text generation, simplify the code, and enhance clarity. The changes include removing support for certain fields, streamlining the logic for frequency and period handling, and adding detailed documentation for the translation logic.

### Updates to `dosage-to-text.py` script:

#### Code simplification and removal of unused fields:
* Removed `frequencyMax` and `periodMax` from frequency-related logic in `def get_frequency(self, dosage)` and updated `def format_period_unit(self, period, unit)` to exclude `periodMax`. This simplifies the frequency calculation and formatting. [[1]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L99-L101) [[2]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L114-R133) [[3]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L220-L223)
* Eliminated the `get_when_and_offset` method and replaced it with `get_when`, focusing only on the `when` field for planned frequency within a time period.

#### Handling unsupported fields:
* Added `frequencyMax` and `periodMax` to the list of unsupported fields in `def get_unsupported_fields(self, dosage)`. This ensures these fields are explicitly flagged as unsupported.

#### Improved logic for dosage text generation:
* Enhanced the `generate_single_dosage_text` method by adding comments for clarity, restructuring the logic into distinct sections (e.g., time period, dose, frequency within the time period, and duration), and ensuring freetext dosages are returned directly when present.

### Updates to documentation:

#### Translation logic:
* Added detailed examples of how structured dosage fields are translated into text, including specific formatting for fields like `doseQuantity`, `frequency`, `period`, and `dayOfWeek`. This improves understanding of the text generation process.

#### Supported fields:
* Updated the list of supported fields in `dosage-to-text.md` to remove `frequencyMax` and `periodMax`, reflecting the changes in the script.

#### Freitext handling:
* Clarified that freetext dosages in the `.text` field are directly outputted without further processing.

These updates streamline the script, improve maintainability, and enhance the documentation for better usability and clarity.