### PR TITLE
refactor: remove free-text dosage handling and update extension logic

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -12,6 +12,10 @@ class GermanDosageTextGenerator:
             felder = ", ".join(unsupported_fields)
             return f"Die Dosiskonfiguration mit den Feldern {felder} wird in der aktuellen Ausbaustufe nicht unterstützt."
         
+        # If free-text override is present, return empty string
+        if dosage.get('text'):
+            return ""
+        
         # Frequency
         frequency = self.get_frequency(dosage)
         if frequency:
@@ -39,9 +43,6 @@ class GermanDosageTextGenerator:
         bounds = self.get_bounds(dosage)
         if bounds:
             elements.append(bounds)
-        # Free text
-        if dosage.get('text'):
-            elements.append(dosage['text'])
         return " — ".join(elements)
     
     def get_unsupported_fields(self, dosage):

--- a/input/includes/supported-dosage-examples.md
+++ b/input/includes/supported-dosage-examples.md
@@ -11,7 +11,7 @@
 |[MedicationRequest-Example-MR-Dosage-UnitStueck-1020](./MedicationRequest-Example-MR-Dosage-UnitStueck-1020.html) | täglich — je 1 Stück — morgens<br><br>täglich — je 2 Stück — abends |
 |[MedicationRequest-Example-MR-Dosage-comb-dayofweek-2](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-2.html) | Montag und Freitag — je 1 Stück — morgens und abends<br><br>Dienstag und Samstag — je 2 Stück — morgens und abends |
 |[MedicationRequest-Example-MR-Dosage-10120](./MedicationRequest-Example-MR-Dosage-10120.html) | täglich — je 1 Stück — morgens<br><br>täglich — je 0.5 Stück — abends |
-|[MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) | täglich — 2 Tabletten morgens zum Frühstück |
+|[MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) |  |
 |[MedicationRequest-Example-MR-Dosage-comb-dayofweek-3](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-3.html) | Montag und Freitag — je 1 Stück — morgens — für 3 Woche(n)<br><br>Montag und Freitag — je 2 Stück — mittags — für 3 Woche(n) |
 |[MedicationRequest-Example-MR-Dosage-1010-10-Days](./MedicationRequest-Example-MR-Dosage-1010-10-Days.html) | täglich — je 1 Stück — morgens und abends — für 10 Woche(n) |
 |[MedicationRequest-Example-MR-Dosage-tod-2-12am](./MedicationRequest-Example-MR-Dosage-tod-2-12am.html) | täglich — je 2 Stück — um 12:00 Uhr |

--- a/scripts/add-dosage-extension.py
+++ b/scripts/add-dosage-extension.py
@@ -33,20 +33,36 @@ def add_extension_to_medicationresource(file_path, dosage_text):
     # Handle MedicationRequest: dosageInstruction
     if "dosageInstruction" in data and data["dosageInstruction"]:
         for dosage in data["dosageInstruction"]:
+            # Filter existing extensions
             if "extension" in dosage:
-                dosage["extension"] = filter_extensions(dosage["extension"])
+                existing_exts = filter_extensions(dosage["extension"])
             else:
-                dosage["extension"] = []
-            dosage["extension"].append(extension)
+                existing_exts = []
+            # Only add the new extension if dosage_text is non-empty
+            if dosage_text:
+                existing_exts.append(extension)
+            # Only set the extension property if there's at least one extension
+            if existing_exts:
+                dosage["extension"] = existing_exts
+            else:
+                dosage.pop("extension", None)
 
     # Handle MedicationStatement: dosage
     if "dosage" in data and data["dosage"]:
         for dosage in data["dosage"]:
+            # Filter existing extensions
             if "extension" in dosage:
-                dosage["extension"] = filter_extensions(dosage["extension"])
+                existing_exts = filter_extensions(dosage["extension"])
             else:
-                dosage["extension"] = []
-            dosage["extension"].append(extension)
+                existing_exts = []
+            # Only add the new extension if dosage_text is non-empty
+            if dosage_text:
+                existing_exts.append(extension)
+            # Only set the extension property if there's at least one extension
+            if existing_exts:
+                dosage["extension"] = existing_exts
+            else:
+                dosage.pop("extension", None)
 
     # Overwrite the file (or write to a new file)
     with open(file_path, 'w', encoding='utf-8') as f:

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -12,6 +12,10 @@ class GermanDosageTextGenerator:
             felder = ", ".join(unsupported_fields)
             return f"Die Dosiskonfiguration mit den Feldern {felder} wird in der aktuellen Ausbaustufe nicht unterstützt."
         
+        # If free-text override is present, return empty string
+        if dosage.get('text'):
+            return ""
+        
         # Frequency
         frequency = self.get_frequency(dosage)
         if frequency:
@@ -39,9 +43,6 @@ class GermanDosageTextGenerator:
         bounds = self.get_bounds(dosage)
         if bounds:
             elements.append(bounds)
-        # Free text
-        if dosage.get('text'):
-            elements.append(dosage['text'])
         return " — ".join(elements)
     
     def get_unsupported_fields(self, dosage):


### PR DESCRIPTION
This pull request introduces changes to improve handling of free-text dosage overrides and extensions in dosage-related scripts and documentation. The updates ensure that free-text overrides are properly handled in dosage text generation and extensions are filtered and added conditionally. Additionally, the documentation has been updated to reflect these changes.

### Handling free-text dosage overrides:

* [`input/content/dosage-to-text.py`](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7R15-R18): Updated `generate_single_dosage_text` to return an empty string when a free-text override is present, and removed appending free-text to the generated dosage text. [[1]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7R15-R18) [[2]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L42-L44)
* [`scripts/dosage-to-text.py`](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7R15-R18): Made identical changes to `generate_single_dosage_text` for consistency across scripts. [[1]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7R15-R18) [[2]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L42-L44)

### Conditional extension handling:

* [`scripts/add-dosage-extension.py`](diffhunk://#diff-d2b063df2b84399c1a338a1567969c2257965886894a722dfb6004c695729849R36-R65): Enhanced `filter_extensions` to conditionally add new extensions only if `dosage_text` is non-empty, and to remove the `extension` property entirely if no extensions remain.

### Documentation update:

* [`input/includes/supported-dosage-examples.md`](diffhunk://#diff-94eb29bbe264b50c14fedb8c5b35d99ec5cc45596df18ce23b8d475764db4ac1L14-R14): Updated the example for free-text dosage to display an empty string, aligning with the new handling logic.