### PR TITLE
fix fhirpath for dosage schemes

### DIFF
--- a/input/pagecontent/timing-comb-dayofweek-scheme.md
+++ b/input/pagecontent/timing-comb-dayofweek-scheme.md
@@ -31,14 +31,16 @@ Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die A
 
 ```
 timing.repeat.dayOfWeek.exists() and
-timing.repeat.frequency.empty() and
-timing.repeat.period.empty() and
-timing.repeat.periodUnit.empty() and
+timing.repeat.frequency.exists() and
+timing.repeat.period.exists() and
+timing.repeat.periodUnit = 'wk' and
   (
     (timing.repeat.timeOfDay.exists() and timing.repeat.when.empty()) or
     (timing.repeat.when.exists() and timing.repeat.timeOfDay.empty())
   )
 ```
+
+Der Wert von frequency entspricht dabei dem Produkt aus der Anzahl von Elementen in `when`, bzw. `timeOfDay` und `dayOfWeek`.
 
 und entweder `when` oder `timeOfDay`. Damit kann diese Dosierangabe verwendet werden um eine Interval angabe auf Tageszeit oder Uhrzeit zu kombinieren.
 

--- a/input/pagecontent/timing-comb-interval-scheme.md
+++ b/input/pagecontent/timing-comb-interval-scheme.md
@@ -39,6 +39,8 @@ timing.repeat.dayOfWeek.empty() and
   )
 ```
 
+Der Wert von frequency entspricht dabei der Anzahl an Elementen in `when`, bzw. `timeOfDay`.
+
 und entweder `when` oder `timeOfDay`. Damit kann diese Dosierangabe verwendet werden um eine Interval angabe auf Tageszeit oder Uhrzeit zu kombinieren.
 
 Lesende Systeme werten entsprechend auch `Dosage.timing.repeat` aus. 

--- a/input/pagecontent/timing-mman-scheme.md
+++ b/input/pagecontent/timing-mman-scheme.md
@@ -37,12 +37,14 @@ Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die A
 
 ```
 timing.repeat.when.exists() and
-timing.repeat.frequency.empty() and
-timing.repeat.period.empty() and
-timing.repeat.periodUnit.empty() and
+timing.repeat.frequency.exists() and
+timing.repeat.period = 1 and
+timing.repeat.periodUnit = 'd' and
 timing.repeat.timeOfDay.empty() and
 timing.repeat.dayOfWeek.empty()
 ```
+
+Der Wert von frequency entspricht dabei der Anzahl an Elementen in `when`.
 
 Soll das Arzneimittel in derselben Dosierung zu mehreren Tageszeiten angewandt werden, wird dies über mehrere Angaben von "when" ausgedrückt. Die angegebene Dosierung ist dann zu jeder der genannten Tageszeiten anzuwenden. 
 

--- a/input/pagecontent/timing-timeofday-scheme.md
+++ b/input/pagecontent/timing-timeofday-scheme.md
@@ -34,12 +34,14 @@ Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die A
 
 ```
 timing.repeat.timeOfDay.exists() and
-timing.repeat.frequency.empty() and
-timing.repeat.period.empty() and
-timing.repeat.periodUnit.empty() and
+timing.repeat.frequency.exists() and
+timing.repeat.period = 1 and
+timing.repeat.periodUnit = 'd' and
 timing.repeat.when.empty() and
 timing.repeat.dayOfWeek.empty()
 ```
+
+Der Wert von frequency entspricht dabei der Anzahl an Elementen in `timeOfDay`.
 
 Soll das Arzneimittel in derselben Dosierung zu mehreren Uhrzeiten angewandt werden, wird dies über mehrere Angaben von `.timeOfDay` ausgedrückt. Die angegebene Dosierung ist dann zu jeder der genannten Uhrzeiten anzuwenden.
 

--- a/input/pagecontent/timing-weekday-scheme.md
+++ b/input/pagecontent/timing-weekday-scheme.md
@@ -38,12 +38,13 @@ Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die A
 
 ```
 timing.repeat.dayOfWeek.exists() and
-timing.repeat.frequency.empty() and
-timing.repeat.period.empty() and
-timing.repeat.periodUnit.empty() and
+timing.repeat.frequency.exists() and
+timing.repeat.period = 1 and
+timing.repeat.periodUnit = 'wk' and
 timing.repeat.when.empty() and
 timing.repeat.timeOfDay.empty()
 ```
+Der Wert von frequency entspricht dabei der Anzahl an Elementen in `dayOfWeek`.
 
 Soll das Arzneimittel in derselben Dosierung an mehreren Tagen angewandt werden, wird dies über mehrere Angaben von `dayOfWeek` ausgedrückt. Die angegebene Dosierung ist dann zu jedem der genannten Tage anzuwenden.
 


### PR DESCRIPTION
This pull request updates several FHIR-Path expressions related to `Dosage.timing.repeat` across multiple documentation files. The changes ensure that frequency, period, and periodUnit are explicitly defined, improving clarity and standardization in dosage instructions. Additionally, explanations about how frequency values are derived have been added to enhance understanding.

### Updates to FHIR-Path expressions:

* **General improvements to `timing.repeat` logic**:
  - Modified expressions to ensure `frequency`, `period`, and `periodUnit` are explicitly defined for better clarity and standardization. For example, `timing.repeat.frequency.exists()` and `timing.repeat.periodUnit` values are now explicitly set across all schemes. [[1]](diffhunk://#diff-4f49ab517bb6565beb1d04ae0ccf61db8967cf5e8e09a9b21bf0897530a631c4L34-R44) [[2]](diffhunk://#diff-66e2db7161ccc707248b126cdaf856bf350b73eec4063fae65929f4920d79d8bL40-R48) [[3]](diffhunk://#diff-f908a4a89828e3c3fa23f7d39a2b0e1c1a0568dfd849603b603bb7693e2132b3L37-R45) [[4]](diffhunk://#diff-52a4b5cc7f4b5ae8d25805a288262a5d5b45258a5c719cd7e4127fbc05deb868L41-R47)

### Added explanatory notes:

* **Frequency derivations**:
  - Added explanations about how the `frequency` value is calculated based on the number of elements in `when`, `timeOfDay`, or `dayOfWeek`, depending on the context. These notes clarify the logic behind frequency values for different timing schemes. [[1]](diffhunk://#diff-4f49ab517bb6565beb1d04ae0ccf61db8967cf5e8e09a9b21bf0897530a631c4L34-R44) [[2]](diffhunk://#diff-2f2cc1439696212ca4f5faab5caa472585f1b058fee05138321a30fecdbe8389R42-R43) [[3]](diffhunk://#diff-66e2db7161ccc707248b126cdaf856bf350b73eec4063fae65929f4920d79d8bL40-R48) [[4]](diffhunk://#diff-f908a4a89828e3c3fa23f7d39a2b0e1c1a0568dfd849603b603bb7693e2132b3L37-R45) [[5]](diffhunk://#diff-52a4b5cc7f4b5ae8d25805a288262a5d5b45258a5c719cd7e4127fbc05deb868L41-R47)