### PR TITLE
Fix-constraint

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -11,6 +11,7 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * obeys TimingOnlyOneType
   * obeys TimingIntervalOnlyOneFrequency
   * obeys TimingOnlyOneWhen
+  * obeys TimingOnlyWhenOrTimeOfDay
   * obeys TimingOnlyOneTimeOfDay
   * obeys TimingOnlyOneDayOfWeek
   * obeys TimingOnlyOnePeriodForDayOfWeek

--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -182,7 +182,7 @@ Expression: "(
     timing.repeat.periodUnit.exists() and
     timing.repeat.dayOfWeek.empty() and
     (timing.repeat.when.exists() or 
-    timing.repeat.timeOfDay.empty())
+    timing.repeat.timeOfDay.exists())
   implies
   (
     (

--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -169,6 +169,37 @@ Expression: "( /* Detect 4-Schema */
 "
 Severity: #error
 
+Invariant: TimingOnlyWhenOrTimeOfDay
+Description: "Dosages Timings must not state a time of day and period of day across multiple dosage instances"
+Expression: "(
+  %resource.ofType(MedicationRequest).dosageInstruction
+  | %resource.ofType(MedicationDispense).dosageInstruction
+  | %resource.ofType(MedicationStatement).dosage
+).all(
+    timing.repeat.frequency.exists() and
+    timing.repeat.period.exists() and
+    timing.repeat.periodUnit.exists() and
+    timing.repeat.dayOfWeek.empty() and
+    (timing.repeat.when.exists() or 
+    timing.repeat.timeOfDay.empty())
+  implies
+  (
+    (
+      (%resource.ofType(MedicationRequest).exists() or %resource.ofType(MedicationDispense).exists())
+      implies
+      (%resource.dosageInstruction.timing.repeat.when.exists() xor %resource.dosageInstruction.timing.repeat.timeOfDay.exists())
+    )
+    and
+    (
+      %resource.ofType(MedicationStatement).exists()
+      implies
+      (%resource.dosage.timing.repeat.when.exists() xor %resource.dosage.timing.repeat.timeOfDay.exists())
+    )
+  )
+)
+"
+Severity: #error
+
 Invariant: TimingOnlyOneTimeOfDay
 Description: "Dosages Timings must not state the same time of day across multiple dosage instances"
 Expression: "( /* Detect TimeOfDay */

--- a/input/fsh/examples/dev_examples_invalid_onekind.fsh
+++ b/input/fsh/examples/dev_examples_invalid_onekind.fsh
@@ -1,5 +1,5 @@
 // when + timeOfDay
-Instance: Invalid-C-TimingOnlyOneType-01-of-08
+Instance: Invalid-C-TimingOnlyWhenOrTimeOfDay-01-of-08
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Invalid: when + timeOfDay"

--- a/input/includes/dosage-constraint-TimingOnlyOneType-examples.md
+++ b/input/includes/dosage-constraint-TimingOnlyOneType-examples.md
@@ -8,7 +8,5 @@
 |  | täglich: je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  |  |  |  |
 | [MedicationRequest-Invalid-C-TimingOnlyOneType-06-of-08](./MedicationRequest-Invalid-C-TimingOnlyOneType-06-of-08.html) | wöchentlich: Dienstag — je 1 Stück | 1 Stück |  |  | 1 | 1 | wk | tue |  |  |  |
 |  | täglich: je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  |  |  |  |
-| [MedicationRequest-Invalid-C-TimingOnlyOneType-01-of-08](./MedicationRequest-Invalid-C-TimingOnlyOneType-01-of-08.html) | täglich: morgens — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  |  | MORN |  |
-|  | täglich: um 08:00 Uhr — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  | 08:00:00 |  |  |
 | [MedicationRequest-Invalid-C-TimingOnlyOneType-04-of-08](./MedicationRequest-Invalid-C-TimingOnlyOneType-04-of-08.html) | täglich: um 07:00 Uhr — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  | 07:00:00 |  |  |
 |  | wöchentlich: Freitag — je 1 Stück | 1 Stück |  |  | 1 | 1 | wk | fri |  |  |  |

--- a/input/includes/dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md
+++ b/input/includes/dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md
@@ -1,0 +1,4 @@
+| File | description | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationRequest-Invalid-C-TimingOnlyWhenOrTimeOfDay-01-of-08](./MedicationRequest-Invalid-C-TimingOnlyWhenOrTimeOfDay-01-of-08.html) | täglich: morgens — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  |  | MORN |  |
+|  | täglich: um 08:00 Uhr — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  | 08:00:00 |  |  |

--- a/input/pagecontent/dosage-constraints.md
+++ b/input/pagecontent/dosage-constraints.md
@@ -44,6 +44,16 @@ Dadurch wird verhindert, dass Dosierungen mehrfach für denselben Zeitraum angeg
 
 {% include dosage-constraint-TimingOnlyOneWhen-examples.md%}
 
+### TimingOnlyWhenOrTimeOfDay
+
+**Beschreibung:**  
+Es darf nicht die Tageszeit `timeOfDay` und der Zeitraum des Tages `when` in mehreren Dosierungsinstanzen gleichzeitig vorkommen.
+
+**Warum?**  
+Dadurch wird verhindert, dass Dosierungen gemischte Schemata anzeigen.
+
+{% include dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md%}
+
 ### TimingOnlyOneTimeOfDay
 
 **Beschreibung:**  


### PR DESCRIPTION
This pull request introduces a new invariant, `TimingOnlyWhenOrTimeOfDay`, to the `TimingDgMP.fsh` file to enforce stricter validation rules for dosage timings. Additionally, the invariant is integrated into the existing constraints for the Timing data type.

### Enhancements to dosage timing validation:

* **New invariant added**: Introduced `TimingOnlyWhenOrTimeOfDay` to ensure that dosage timings do not specify both a time of day and a period of the day across multiple dosage instances. This invariant includes a detailed `Expression` to validate the rule for `MedicationRequest`, `MedicationDispense`, and `MedicationStatement` resources.
* **Constraint integration**: Added the `TimingOnlyWhenOrTimeOfDay` invariant to the list of constraints applied to the `Timing` data type, ensuring it is enforced consistently.