### PR TITLE
add frequency information to descriptions

### DIFF
--- a/input/pagecontent/timing-comb-dayofweek-scheme.md
+++ b/input/pagecontent/timing-comb-dayofweek-scheme.md
@@ -25,7 +25,12 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 Diese Dosierungsart wird daran erkannt, dass folgende Felder unter `Dosage.timing.repeat` angegeben sind:
 
-- `when` ODER `dayOfWeek` existieren
+- `dayOfWeek`
+- `frequency`
+- `period`
+- `periodUnit` in Wochen (wk)
+- und `when` ODER `timeOfDay` existieren
+- opt. Angabe von `bounds[x]`
 
 Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die Angabe, ob es sich um das Schema handelt: 
 

--- a/input/pagecontent/timing-interval-scheme.md
+++ b/input/pagecontent/timing-interval-scheme.md
@@ -24,9 +24,9 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 Diese Dosierungsart wird daran erkannt, dass folgende Felder unter `Dosage.timing.repeat` angegeben sind:
 
-- frequency
-- period
-- periodUnit
+- `frequency`
+- `period`
+- `periodUnit`
 - opt. Angabe von `bounds[x]`
 
 Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die Angabe, ob es sich um das Schema handelt: 

--- a/input/pagecontent/timing-mman-scheme.md
+++ b/input/pagecontent/timing-mman-scheme.md
@@ -28,7 +28,10 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 Diese Dosierungsart wird daran erkannt, dass unter `Dosage.timing.repeat`
 
-- ausschließliche Angabe von `when`
+- `when`
+- `frequency`
+- `period`
+- `periodUnit` in Tagen (d)
 - opt. Angabe von `bounds[x]`
   
 angegeben ist. An diesem Feld wird dann kodiert die Tageszeit angegeben an der eine konkrete Dosierung einzunehmen ist.

--- a/input/pagecontent/timing-timeofday-scheme.md
+++ b/input/pagecontent/timing-timeofday-scheme.md
@@ -25,7 +25,10 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 Diese Dosierungsart wird daran erkannt, dass unter `Dosage.timing.repeat`
 
-- ausschließliche Angabe von `timeOfDay`
+- `frequency`
+- `period`
+- `periodUnit` in Tagen (d)
+- `timeOfDay`
 - opt. Angabe von `bounds[x]`
 
 angegeben ist. An diesem Feld wird dann kodiert die Uhrzeit angegeben an der eine konkrete Dosierung einzunehmen ist.

--- a/input/pagecontent/timing-weekday-scheme.md
+++ b/input/pagecontent/timing-weekday-scheme.md
@@ -29,7 +29,10 @@ Folgende Beispiele sind in diesem IG dargestellt:
 
 Diese Dosierungsart wird daran erkannt, dass unter `Dosage.timing.repeat`
 
-- ausschließliche Angabe von `dayOfWeek`
+- `dayOfWeek`
+- `frequency`
+- `period`
+- `periodUnit` in Wochen (wk)
 - opt. Angabe von `bounds[x]`
 
 angegeben ist. An diesem Feld wird dann kodiert der Wochentag angegeben an der eine konkrete Dosierung einzunehmen ist.


### PR DESCRIPTION
This pull request updates the descriptions of dosage timing schemes across multiple markdown files in the project. The changes primarily involve refining the listed fields under `Dosage.timing.repeat` for various timing schemes to ensure consistency and clarity.

### Updates to dosage timing scheme descriptions:

  - Updated the required pages to include `frequency`, `period`, `periodUnit. e.g. (`input/pagecontent/timing-comb-dayofweek-scheme.md`, [input/pagecontent/timing-comb-dayofweek-scheme.mdL28-R33](diffhunk://#diff-4f49ab517bb6565beb1d04ae0ccf61db8967cf5e8e09a9b21bf0897530a631c4L28-R33))
