### PR TITLE
fix: correct capitalization of 'Nacht' in dosage text

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -234,7 +234,7 @@ class GematikDosageTextGenerator:
             'MORN': 'morgens',
             'NOON': 'mittags',
             'EVE': 'abends',
-            'NIGHT': 'zur nacht'
+            'NIGHT': 'zur Nacht'
         }
         return when_codes.get(when.upper(), when)
 

--- a/input/includes/dosage-timing-matrix.md
+++ b/input/includes/dosage-timing-matrix.md
@@ -3,7 +3,7 @@
 | [MedicationRequest-Example-MR-Dosage-comb-interval-1](./MedicationRequest-Example-MR-Dosage-comb-interval-1.html) | alle 2 Tage: um 08:00 Uhr — je 1 Stück | 1 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
 |  | alle 2 Tage: um 18:00 Uhr — je 2 Stück | 2 Stück |  |  | 1 | 2 | d |  | 18:00:00 |  |  |
 | [MedicationRequest-Example-MR-Dosage-interval-3d](./MedicationRequest-Example-MR-Dosage-interval-3d.html) | alle 3 Tage: je 1 Stück | 1 Stück |  |  | 1 | 3 | d |  |  |  |  |
-| [MedicationRequest-Example-MR-Dosage-1111](./MedicationRequest-Example-MR-Dosage-1111.html) | 4 x täglich: morgens, mittags, abends und zur nacht — je 1 Stück | 1 Stück |  |  | 4 | 1 | d |  |  | EVE, MORN, NIGHT, NOON |  |
+| [MedicationRequest-Example-MR-Dosage-1111](./MedicationRequest-Example-MR-Dosage-1111.html) | 4 x täglich: morgens, mittags, abends und zur Nacht — je 1 Stück | 1 Stück |  |  | 4 | 1 | d |  |  | EVE, MORN, NIGHT, NOON |  |
 | [MedicationRequest-Example-MR-Dosage-UnitMg-1000](./MedicationRequest-Example-MR-Dosage-UnitMg-1000.html) | täglich: morgens — je 400 mg | 400 mg |  |  | 1 | 1 | d |  |  | MORN |  |
 | [MedicationRequest-Example-MR-Dosage-interval-2d-bound](./MedicationRequest-Example-MR-Dosage-interval-2d-bound.html) | für 6 Woche(n) alle 2 Tage: je 2 Stück | 2 Stück |  |  | 1 | 2 | d |  |  |  | {'system': 'http://unitsofmeasure.org', 'value': 6, 'code': 'wk', 'unit': 'Woche(n)'} |
 | [MedicationRequest-Example-MR-Dosage-interval-4times-d](./MedicationRequest-Example-MR-Dosage-interval-4times-d.html) | 4 x täglich: je 1 Stück | 1 Stück |  |  | 4 | 1 | d |  |  |  |  |

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -234,7 +234,7 @@ class GematikDosageTextGenerator:
             'MORN': 'morgens',
             'NOON': 'mittags',
             'EVE': 'abends',
-            'NIGHT': 'zur nacht'
+            'NIGHT': 'zur Nacht'
         }
         return when_codes.get(when.upper(), when)
 


### PR DESCRIPTION
This pull request includes minor updates to standardize the capitalization of the word "Nacht" in both code and documentation. These changes ensure consistency in text formatting across the project.

### Updates to text capitalization:

* [`input/content/dosage-to-text.py`](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L237-R237): Corrected the capitalization of the word "Nacht" in the translation mapping for the `NIGHT` code.
* [`scripts/dosage-to-text.py`](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L237-R237): Corrected the capitalization of the word "Nacht" in the translation mapping for the `NIGHT` code.

### Updates to documentation:

* [`input/includes/dosage-timing-matrix.md`](diffhunk://#diff-47b9ee64d6e1f221cc9fe671523ce5a7b75407b88d2519aeaa8aac045d5a6cc7L6-R6): Updated the capitalization of "zur Nacht" in the description for `MedicationRequest-Example-MR-Dosage-1111`.