### PR TITLE
refactor: update dosage terminology from 'Tablette' to 'Stück' in examples and descriptions

### DIFF
--- a/input/fsh/datatypes/DosageDE.fsh
+++ b/input/fsh/datatypes/DosageDE.fsh
@@ -10,8 +10,8 @@ Description: "Gibt an, wie das Medikament eingenommen oder verabreicht wurde bzw
 * obeys DosageDoseUnitSameCode
 * extension contains GeneratedDosageInstructionsEx named generatedDosageInstructions 0..1 MS
 * text 0..1 MS
-  * ^short = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'"
-  * ^definition = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Tablette bei Bedarf'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"
+  * ^short = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Stück bei Bedarf'"
+  * ^definition = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Stück bei Bedarf'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"
   * ^comment = "Die Freitextdosierung sollte nur angegeben werden, wenn aufgrund der Komplexität keine strukturierte Dosierung möglich ist, um widersprüchliche Anweisungen zu vermeiden."
 * timing MS
   * ^short = "Wann das Medikament verabreicht werden soll"

--- a/input/fsh/examples/dev_examples_invalid_multiple.fsh
+++ b/input/fsh/examples/dev_examples_invalid_multiple.fsh
@@ -115,7 +115,7 @@ Instance: Invalid-multiple-06-of-10-C-TimingIntervalOnlyOneFrequency
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Two Interval Dosages"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von jeden 2. Tag 1 Tablette und 3. Tag 2 Tabletten dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von jeden 2. Tag 1 Stück und 3. Tag 2 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -138,7 +138,7 @@ Instance: Invalid-multiple-07-of-10-C-TimingOnlyOneWhen
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Two interval Dosages same period of day"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Tablette um 08:00 Uhr und 1 Tablette um 10:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 Uhr und 1 Stück um 10:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -164,7 +164,7 @@ Instance: Invalid-multiple-08-of-10-C-TimingOnlyOneTimeOfDay
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Two interval Dosages same time"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Tablette um 08:00 Uhr und 1 Tablette um 10:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 Uhr und 1 Stück um 10:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -189,7 +189,7 @@ Instance: Invalid-multiple-09-of-10-C-TimingOnlyOneTimeForInterval
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Two interval Dosages same time"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Tablette um 08:00 Uhr und 1 Tablette um 10:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 Uhr und 1 Stück um 10:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_comb_dayofweek.fsh
+++ b/input/fsh/examples/scheme_examples_comb_dayofweek.fsh
@@ -74,7 +74,7 @@ Instance: Example-MR-Dosage-comb-dayofweek-3
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-dayofweek-3"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Montags und Freitags 1 Tablette Morgens und 2 Tabletten Mittags (1-1-0-0) - für 3 Wochen dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Montags und Freitags 1 Stück Morgens und 2 Stück Mittags (1-1-0-0) - für 3 Wochen dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_comb_interval.fsh
+++ b/input/fsh/examples/scheme_examples_comb_interval.fsh
@@ -2,7 +2,7 @@ Instance: Example-MR-Dosage-comb-interval-1
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-interval-1"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Tablette um 08:00 Uhr und 1 Tablette um 18:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 Uhr und 1 Stück um 18:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -27,7 +27,7 @@ Instance: Example-MR-Dosage-comb-interval-2
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-interval-2"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 x pro Woche 1 Tablette morgens dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 x pro Woche 1 Stück morgens dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -44,7 +44,7 @@ Instance: Example-MR-Dosage-comb-interval-3
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-interval-3"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Tablette um 08:00 Uhr und jeden 2. Tag 1 Tablette um 20:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 Uhr und jeden 2. Tag 1 Stück um 20:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -69,7 +69,7 @@ Instance: Example-MR-Dosage-comb-interval-4
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-interval-4"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Tablette um 08:00 & 20:00 Uhr und jeden 2. Tag 1 Tablette um 08:00, 14:00 und 22:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 & 20:00 Uhr und jeden 2. Tag 1 Stück um 08:00, 14:00 und 22:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_dayOfWeek.fsh
+++ b/input/fsh/examples/scheme_examples_dayOfWeek.fsh
@@ -2,7 +2,7 @@ Instance: Example-MR-Dosage-weekday-2t
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-weekday-2t"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Dienstags und Donnerstags je 2 Tabletten dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Dienstags und Donnerstags je 2 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -20,7 +20,7 @@ Instance: Example-MR-Dosage-weekday-3t
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-weekday-3t"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Dienstags, Donnerstags und Samstag je 2 Tabletten dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Dienstags, Donnerstags und Samstag je 2 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -39,7 +39,7 @@ Instance: Example-MR-Dosage-weekday-2t-1t
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-2t-1t"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Montags 2 Tabletten, Donnerstags 1 Tablette dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Montags 2 Stück, Donnerstags 1 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -82,7 +82,7 @@ Instance: Example-MR-Dosage-weekday-unsorted
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-weekday-unsorted"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von unsortierten Wochentagen je 2 Tabletten dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von unsortierten Wochentagen je 2 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_freetext.fsh
+++ b/input/fsh/examples/scheme_examples_freetext.fsh
@@ -7,4 +7,4 @@ Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Freit
 * status = #active
 * intent = #order
 * medicationCodeableConcept.text = "Ibuprofen 400mg"
-* dosageInstruction[+].text = "2 Tabletten morgens zum Frühstück"
+* dosageInstruction[+].text = "2 Stück morgens zum Frühstück"

--- a/input/fsh/examples/scheme_examples_interval.fsh
+++ b/input/fsh/examples/scheme_examples_interval.fsh
@@ -2,7 +2,7 @@ Instance: Example-MR-Dosage-interval-8d
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-interval-8d"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Tablette alle 8 Tage dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Stück alle 8 Tage dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -17,7 +17,7 @@ Instance: Example-MR-Dosage-interval-2wk
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-interval-2wk"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Tablette alle 2 Wochen dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Stück alle 2 Wochen dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -32,7 +32,7 @@ Instance: Example-MR-Dosage-interval-4times-d
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-interval-4times-d"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 4 x 1 Tablette pro Tag dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 4 x 1 Stück pro Tag dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -47,7 +47,7 @@ Instance: Example-MR-Dosage-interval-3d
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-interval-3d"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Alle 3 Tage 1 Tablette dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Alle 3 Tage 1 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -62,7 +62,7 @@ Instance: Example-MR-Dosage-interval-2d-bound
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-interval-2d"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Alle 2 Tage 2 Tabletten für 6 Wochen dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Alle 2 Tage 2 Stück für 6 Wochen dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_timeOfDay.fsh
+++ b/input/fsh/examples/scheme_examples_timeOfDay.fsh
@@ -2,7 +2,7 @@ Instance: Example-MR-Dosage-tod-1t-8am
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-tod-1t-8am"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Tablette um 08:00"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Stück um 08:00"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -19,7 +19,7 @@ Instance: Example-MR-Dosage-tod-2-12am
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-tod-2-12am"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 2 Tabletten um 12:00 Uhr"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 2 Stück um 12:00 Uhr"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -36,7 +36,7 @@ Instance: Example-MR-Dosage-tod-multi
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-tod-multi"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 8 Uhr: 2 Tabletten - 11 Uhr: 1 Tablette - 14 Uhr: 1 Tablette - 17 Uhr: 1 Tablette - 20 Uhr: 1 Tablette - 23 Uhr: 1 Tablette dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 8 Uhr: 2 Stück - 11 Uhr: 1 Stück - 14 Uhr: 1 Stück - 17 Uhr: 1 Stück - 20 Uhr: 1 Stück - 23 Uhr: 1 Stück dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -65,7 +65,7 @@ Instance: Example-MR-Dosage-tod-multi-bound
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-tod-multi-bound"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung 8 Uhr: 2 Tabletten - 11 Uhr: 1 Tablette - 14 Uhr: 1 Tablette - 17 Uhr: 1 Tablette - 20 Uhr: 1 Tablette - 23 Uhr: 1 Tablette, für 10 Tage"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung 8 Uhr: 2 Stück - 11 Uhr: 1 Stück - 14 Uhr: 1 Stück - 17 Uhr: 1 Stück - 20 Uhr: 1 Stück - 23 Uhr: 1 Stück, für 10 Tage"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -96,7 +96,7 @@ Instance: Example-MR-Dosage-tod-unsorted
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-tod-unsorted"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Tablette und unsortierten Zeiten dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von 1 Stück und unsortierten Zeiten dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order


### PR DESCRIPTION
This pull request updates the terminology used in dosage instructions and example descriptions throughout the codebase. Specifically, it replaces the term "Tablette" (tablet) with "Stück" (piece) to generalize medication units in both free-text fields and example instances. This ensures consistency.

**Terminology update in dosage instructions and examples:**

* Updated the `^short` and `^definition` fields for the `text` element in `DosageDE.fsh` to use "Stück" instead of "Tablette" in free-text dosage instructions.
* Modified all relevant example descriptions in files such as `scheme_examples_dayOfWeek.fsh`, `scheme_examples_interval.fsh`, `scheme_examples_timeOfDay.fsh`, `scheme_examples_freetext.fsh`, `scheme_examples_comb_interval.fsh`, `scheme_examples_comb_dayofweek.fsh`, and `dev_examples_invalid_multiple.fsh` to use "Stück" instead of "Tablette" for medication units. [[1]](diffhunk://#diff-d4fcb25719d94261eb5c6aeb6c5f464c2d8b24b90e9ffb67a851aafb98be18d5L5-R5) [[2]](diffhunk://#diff-d4fcb25719d94261eb5c6aeb6c5f464c2d8b24b90e9ffb67a851aafb98be18d5L23-R23) [[3]](diffhunk://#diff-d4fcb25719d94261eb5c6aeb6c5f464c2d8b24b90e9ffb67a851aafb98be18d5L42-R42) [[4]](diffhunk://#diff-d4fcb25719d94261eb5c6aeb6c5f464c2d8b24b90e9ffb67a851aafb98be18d5L85-R85) [[5]](diffhunk://#diff-0e7eee8c7754a2c55c97e0f3ffaecdfab1ef72835362b80ec3f97035d73cdd57L5-R5) [[6]](diffhunk://#diff-0e7eee8c7754a2c55c97e0f3ffaecdfab1ef72835362b80ec3f97035d73cdd57L20-R20) [[7]](diffhunk://#diff-0e7eee8c7754a2c55c97e0f3ffaecdfab1ef72835362b80ec3f97035d73cdd57L35-R35) [[8]](diffhunk://#diff-0e7eee8c7754a2c55c97e0f3ffaecdfab1ef72835362b80ec3f97035d73cdd57L50-R50) [[9]](diffhunk://#diff-0e7eee8c7754a2c55c97e0f3ffaecdfab1ef72835362b80ec3f97035d73cdd57L65-R65) [[10]](diffhunk://#diff-57701ee62ac89fae1191b0a48280f48a3f5a06498b5ddc22a652c0064afa7567L5-R5) [[11]](diffhunk://#diff-57701ee62ac89fae1191b0a48280f48a3f5a06498b5ddc22a652c0064afa7567L22-R22) [[12]](diffhunk://#diff-57701ee62ac89fae1191b0a48280f48a3f5a06498b5ddc22a652c0064afa7567L39-R39) [[13]](diffhunk://#diff-57701ee62ac89fae1191b0a48280f48a3f5a06498b5ddc22a652c0064afa7567L68-R68) [[14]](diffhunk://#diff-57701ee62ac89fae1191b0a48280f48a3f5a06498b5ddc22a652c0064afa7567L99-R99) [[15]](diffhunk://#diff-6996d6ef57165b93b6ae067bb5bedcf6bf9e8690192620720a84ca94f9dc2917L5-R5) [[16]](diffhunk://#diff-6996d6ef57165b93b6ae067bb5bedcf6bf9e8690192620720a84ca94f9dc2917L30-R30) [[17]](diffhunk://#diff-6996d6ef57165b93b6ae067bb5bedcf6bf9e8690192620720a84ca94f9dc2917L47-R47) [[18]](diffhunk://#diff-6996d6ef57165b93b6ae067bb5bedcf6bf9e8690192620720a84ca94f9dc2917L72-R72) [[19]](diffhunk://#diff-4089768bdd22c46afd3e72353fce50a1f9ebb38d70ca3732fa21b952705b7b56L77-R77) [[20]](diffhunk://#diff-de4636f8640a32edbd99a8dd9d5a6be10a2586d076b2ce72b4b0693be6881a7dL118-R118) [[21]](diffhunk://#diff-de4636f8640a32edbd99a8dd9d5a6be10a2586d076b2ce72b4b0693be6881a7dL141-R141) [[22]](diffhunk://#diff-de4636f8640a32edbd99a8dd9d5a6be10a2586d076b2ce72b4b0693be6881a7dL167-R167) [[23]](diffhunk://#diff-de4636f8640a32edbd99a8dd9d5a6be10a2586d076b2ce72b4b0693be6881a7dL192-R192) [[24]](diffhunk://#diff-e538c27575f9abd341ae6bc13fa18406a91c2b16526deb32ee9084084372b498L10-R10)

These changes help standardize medication dosage language and make the examples more flexible for different medication forms.