### PR TITLE
fix: update link in dosage text generation documentation

### DIFF
--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -1,5 +1,5 @@
 *Hinweis:*  
-Ein Großteil der Logik basiert auf den Empfehlungen aus Dose to Text Translation ([UK Core Implementation Guide for Medicines](https://simplifier.net/guide/ukcoreimplementationguideformedicines/ReferenceArchitectures2?version=current)).
+Ein Großteil der Logik basiert auf den Empfehlungen aus Dose to Text Translation ([UK Core Implementation Guide for Medicines](https://simplifier.net/guide/ukcoreimplementationguideformedicines/DosetoTextTranslation?version=current)).
 
 Für eine menschenlesbare Darstellung der Dosierung ist das Feld .text derart zu befüllen, dass die strukturierten Dosierinformationen textuell dargestellt werden.  
 Diese Seite beschreibt den Algorithmus, wie die strukturierten Dosierinformationen in einen String überführt werden können.


### PR DESCRIPTION
This pull request updates a reference link in the documentation to point directly to the relevant section on dose-to-text translation.

- Documentation update:
  * Changed the hyperlink in `input/pagecontent/dosierung-textgenerierung.md` to reference the specific "Dose to Text Translation" section of the UK Core Implementation Guide for Medicines.