### PR TITLE
Fix der Timing Tabelle,  Verbesserung des python scripts, HDB-650

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -82,6 +82,19 @@ class GematikDosageTextGenerator:
             if key in deny_timing_repeat_fields:
                 unsupported.add(f"timing.repeat.{key}")
             
+    # only allow specific 'when' codes
+    supported_when = {"MORN", "NOON", "EVE", "NIGHT"}
+    when_list = repeat.get("when", [])
+    invalid_when = []
+    for w in when_list:
+        w_up = str(w).upper()
+        if w_up not in supported_when:
+            invalid_when.append(w_up)
+    # add each invalid code separately so they alle erscheinen in der Meldung
+    for w_up in sorted(set(invalid_when)):
+        unsupported.add(f"timing.repeat.when={w_up}")
+    # <<< NEW
+
         return list(unsupported)
 
     def get_dose(self, dosage):

--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -90,10 +90,9 @@ class GematikDosageTextGenerator:
         w_up = str(w).upper()
         if w_up not in supported_when:
             invalid_when.append(w_up)
-    # add each invalid code separately so they alle erscheinen in der Meldung
+    # add each invalid code separately so they all appear in the error message
     for w_up in sorted(set(invalid_when)):
         unsupported.add(f"timing.repeat.when={w_up}")
-    # <<< NEW
 
         return list(unsupported)
 

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -93,9 +93,8 @@ Im folgenden wird für jedes Element ein Beispiel angegeben, wie die Überführu
 | Element                | Darstellung (Deutsch)                    | Beispiel(e)                    |
 |------------------------|------------------------------------------|--------------------------------|
 | **repeat.boundsDuration** | `für {value} {unit}`                 | `für 7 Tage`                   |
-| **repeat.frequency**      | `{frequency} mal`<br>oder, wenn `period`/`periodUnit` gesetzt:<br>`{frequency} mal pro {period} {periodUnit}` | `3 mal täglich`<br>`2 mal pro Woche` |
-| **repeat.period**         | (falls `frequency` gesetzt)<br>`{frequency} mal alle {period} {periodUnit}` | `3 mal alle 8 Stunden`         |
-| **repeat.periodUnit**     | Zeit-Einheiten:<br>- `s` = Sekunden<br>- `min` = Minuten<br>- `h` = Stunden<br>- `d` = Tage<br>- `wk` = Wochen<br>- `mo` = Monate<br>- `a` = Jahre |                                |
-| **repeat.dayOfWeek**      | `am {dayOfWeek}`<br>Bei mehreren Tagen:<br>`am Montag, Mittwoch und Freitag`<br>(vollständige deutsche Wochentagsnamen verwenden) | `am Dienstag`<br>`am Montag, Mittwoch und Freitag` |
-| **repeat.timeOfDay**      | `um {timeOfDay}`<br>Bei mehreren Zeiten:<br>`um 10:00 und 15:00` | `um 8:00`<br>`um 10:00 und 15:00` |
-| **repeat.when**           | `{when}`<br>(z. B. `morgens`, `mittags`, `abends`, `nachts`)<br>Bei mehreren:<br>`morgens und abends` | `morgens`<br>`morgens und abends` |
+| **repeat.frequency/period/periodUnit**      | `periodUnit='d', period=1, frequency=1` `täglich`<br>`periodUnit='d', period=1, frequency>1` `{frequency} x täglich`<br>`periodUnit='wk', period=1, frequency=1` `wöchentlich`<br>`periodUnit='wk', period=1, frequency>1` `{frequency} x wöchentlich`<br>Sonst, frequency=1 `alle {period} {Einheit}`<br>Sonst, frequency>1 `{frequency} x alle {period} {Einheit}` | `täglich`<br>`2 x wöchentlich`<br>`alle 8 Stunden`<br>`3 x alle 8 Stunden` |
+| **repeat.periodUnit**     | Zeit-Einheiten (mit Singular/Plural):<br>`s` = Sekunde/Sekunden<br>`min` = Minute/Minuten<br>`h` = Stunde/Stunden<br>`d` = Tag/Tage<br>`wk` = Woche/Wochen<br>`mo` = Monat/Monate<br>`a` = Jahr/Jahre | |                                |
+| **repeat.dayOfWeek**      | `{dayOfWeek}`<br>Bei mehreren Tagen:<br>`Montag, Mittwoch und Freitag`<br>(vollständige deutsche Wochentagsnamen verwenden) | `Dienstag`<br>`Montag, Mittwoch und Freitag` |
+| **repeat.timeOfDay**      | `um HH:MM Uhr[, HH:MM Uhr …]` (kommagetrennt, immer mit „Uhr“) | `um 10:00 Uhr`<br>`um 08:00 Uhr, 15:00 Uhr`                    |
+| **repeat.when**           | `MORN` = morgens, `NOON` = mittags, `EVE` = abends, `NIGHT` = zur Nacht<br>Mehrere Werte: bei 2 mit „und“, bei >2 mit Kommata und „und“ | `morgens`<br>`morgens und abends`<br>`morgens, mittags und abends`        |

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -82,6 +82,18 @@ class GematikDosageTextGenerator:
             if key in deny_timing_repeat_fields:
                 unsupported.add(f"timing.repeat.{key}")
             
+    # only allow specific 'when' codes
+    supported_when = {"MORN", "NOON", "EVE", "NIGHT"}
+    when_list = repeat.get("when", [])
+    invalid_when = []
+    for w in when_list:
+        w_up = str(w).upper()
+        if w_up not in supported_when:
+            invalid_when.append(w_up)
+    # add each invalid code separately so they all appear in the error message
+    for w_up in sorted(set(invalid_when)):
+        unsupported.add(f"timing.repeat.when={w_up}")
+
         return list(unsupported)
 
     def get_dose(self, dosage):


### PR DESCRIPTION
This pull request introduces stricter validation for supported `when` codes in dosage repeat timing and updates the documentation to clarify how repeat elements are rendered in German, including more precise rules for frequency and time expressions.

**Validation improvements:**

* Only the `when` codes `MORN`, `NOON`, `EVE`, and `NIGHT` are now allowed in the `timing.repeat.when` field; any unsupported codes are explicitly reported as unsupported fields.

**Documentation updates:**

* The table in `dosierung-textgenerierung.md` was updated to:
  * Clarify and consolidate how combinations of `repeat.frequency`, `repeat.period`, and `repeat.periodUnit` are rendered in German, with new rules for daily and weekly schedules.
  * Specify singular and plural forms for time units.
  * Update examples and formatting for `dayOfWeek`, `timeOfDay`, and `when`, including explicit mappings for `when` codes and improved handling of multiple values.