### PR TITLE
feat: add invariant for structured dosage instructions requiring generated text

### DIFF
--- a/input/fsh/datatypes/DosageDgMP.fsh
+++ b/input/fsh/datatypes/DosageDgMP.fsh
@@ -4,7 +4,7 @@ Id: DosageDgMP
 Title: "Dosage dgMP"
 Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenommen wird/wurde oder eingenommen werden soll."
 * obeys DosageStructuredOrFreeText
-
+* obeys DosageStructuredRequiresGeneratedText
 * extension[generatedDosageInstructions]
   * extension[algorithm] 1..
     * valueCoding  // The algorithm used to generate the text
@@ -58,6 +58,18 @@ Expression: "(%resource.ofType(MedicationRequest).dosageInstruction |
  ofType(MedicationStatement).dosage).all(
   (text.exists() and timing.empty() and doseAndRate.empty()) or
   (text.empty() and (timing.exists() or doseAndRate.exists()))
+)
+"
+Severity: #error
+
+Invariant: DosageStructuredRequiresGeneratedText
+Description: "Liegt eine strukturierte Dosierungsangabe vor (timing und doseAndRate belegt, text leer), muss die Extension GeneratedDosageInstructions vorhanden sein."
+Expression: "(%resource.ofType(MedicationRequest).dosageInstruction | 
+ ofType(MedicationDispense).dosageInstruction | 
+ ofType(MedicationStatement).dosage).all(
+  (timing.exists() and doseAndRate.exists() and text.empty()) 
+  implies 
+  extension.where(url = 'http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructions').exists()
 )
 "
 Severity: #error


### PR DESCRIPTION
This pull request introduces a new validation rule to the `DosageDgMP` datatype to enforce the presence of the `GeneratedDosageInstructions` extension when structured dosage information is provided without free text. The main changes are as follows:

**Validation and Invariants:**

* Added a new invariant, `DosageStructuredRequiresGeneratedText`, to ensure that if `timing` and `doseAndRate` are present and `text` is empty in dosage instructions, the `GeneratedDosageInstructions` extension must be included.
* Applied the new `DosageStructuredRequiresGeneratedText` invariant to the `DosageDgMP` datatype definition.