### PR TITLE
fix: correct description of dosage timing bounds in TimingDgMP.fsh

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -266,7 +266,7 @@ Expression: "( /* Detect DayOfWeek */
 Severity: #error
 
 Invariant: TimingOnlyOneBounds
-Description: "Dosages Timings must not state the same bounds duration across multiple dosage instances"
+Description: "Dosages Timings must state the same bounds duration across multiple dosage instances"
 Expression: "(
   %resource.ofType(MedicationRequest).dosageInstruction
   | %resource.ofType(MedicationDispense).dosageInstruction


### PR DESCRIPTION
This pull request contains a small change to the error message description for the `TimingOnlyOneBounds` invariant. The description was updated to clarify the intended validation logic.