### PR TITLE
feat: made value in duration in TimingDgMP mandatory (1..1), added MS in TimingDE.fsh

### DIFF
--- a/input/fsh/datatypes/TimingDE.fsh
+++ b/input/fsh/datatypes/TimingDE.fsh
@@ -13,9 +13,13 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
 * repeat.boundsDuration MS
   * ^short = "Dauer der Dosieranweisung ausgedrückt in UCUM-Einheiten"
   * ^definition = "Entweder eine Dauer für die Länge des Zeitplans, ein Bereich möglicher Längen oder äußere Begrenzungen für Start- und/oder Endgrenzen des Zeitplans."
+  * system MS
   * system = $ucum (exactly)
     * ^short = "UCUM-Einheit für die Dauer"
     * ^comment = "Die UCUM-Einheit für die Dauer, z. B. d für Tag, h für Stunde, min für Minute."
+  * code MS
+  * unit MS
+  * value MS
 * repeat.frequency MS
   * ^short = "Ereignis tritt frequency-mal pro Zeitraum auf"
   * ^definition = "Die Anzahl der Wiederholungen innerhalb des angegebenen Zeitraums. Falls frequencyMax vorhanden ist, gibt dieses Element die Untergrenze des zulässigen Bereichs der Häufigkeit an."

--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -24,9 +24,10 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
     * ^comment = "Begründung Einschränkung Datentyp: Nur eine Angabe zur Dauer ist in der ersten Ausbaustufe des dgMP vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
   * boundsDuration MS
     * code 1..1 MS
+    * code from DurationUnitsOfTimeDgMPVS (required)
     * system 1..1 MS
     * unit 1..1 MS
-    * code from DurationUnitsOfTimeDgMPVS (required)
+    * value 1..1 MS
   * frequency 1..1 MS
   * period 1..1 MS
   * periodUnit 1..1 MS


### PR DESCRIPTION
This pull request updates FHIR Shorthand (FSH) definitions for timing-related datatypes to improve the specification and consistency of duration elements. The main changes clarify required fields and constraints for duration components in both `TimingDE` and `TimingDgMP` profiles.

**Enhancements to duration specification:**

* [`input/fsh/datatypes/TimingDE.fsh`](diffhunk://#diff-5b014bd5030b7ea4c51ff058bbf1c8ff010c7a48bdd5c8175a0080f286a14806R16-R22): Marked `system`, `code`, `unit`, and `value` as must-support (MS) fields within `repeat.boundsDuration`, ensuring these UCUM duration components are explicitly supported and required.
* [`input/fsh/datatypes/TimingDgMP.fsh`](diffhunk://#diff-17facd63336d466334353eb0f1021bce2ac2ae19d2b61d21253a62314fafadd3R27-R30): Reorganized and clarified constraints for `boundsDuration`, making `code`, `system`, `unit`, and `value` all required (cardinality `1..1`), and ensuring `code` is bound to `DurationUnitsOfTimeDgMPVS`.