### PR TITLE
refactor: rename GematikDosageTextGenerator to DgMPDosageTextGenerator

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -5,7 +5,7 @@ import os
 
 __version__ = "1.0.0"
 
-class GematikDosageTextGenerator:
+class DgmpDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
         # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
@@ -249,7 +249,7 @@ def main():
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             dosage = json.load(file)
-        generator = GematikDosageTextGenerator()
+        generator = DgmpDosageTextGenerator()
         result = generator.generate_single_dosage_text(dosage)
         print(result)
     except json.JSONDecodeError as e:

--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -5,7 +5,7 @@ import os
 
 __version__ = "1.0.0"
 
-class DgmpDosageTextGenerator:
+class DgMPDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
         # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
@@ -249,7 +249,7 @@ def main():
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             dosage = json.load(file)
-        generator = DgmpDosageTextGenerator()
+        generator = DgMPDosageTextGenerator()
         result = generator.generate_single_dosage_text(dosage)
         print(result)
     except json.JSONDecodeError as e:

--- a/input/fsh/datatypes/DosageDgMP.fsh
+++ b/input/fsh/datatypes/DosageDgMP.fsh
@@ -9,7 +9,7 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
   * extension[algorithm] 1..
     * valueCoding  // The algorithm used to generate the text
       * ^patternCoding.system = Canonical(DosageTextAlgorithmCS)
-      * ^patternCoding.code = #DgmpDosageTextGenerator
+      * ^patternCoding.code = #DgMPDosageTextGenerator
   * extension[algorithmVersion] 1.. 
     * valueString // The version of the algorithm used to generate the text
   * extension[language] 1.. 

--- a/input/fsh/datatypes/DosageDgMP.fsh
+++ b/input/fsh/datatypes/DosageDgMP.fsh
@@ -9,7 +9,7 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
   * extension[algorithm] 1..
     * valueCoding  // The algorithm used to generate the text
       * ^patternCoding.system = Canonical(DosageTextAlgorithmCS)
-      * ^patternCoding.code = #GematikDosageTextGenerator
+      * ^patternCoding.code = #DgmpDosageTextGenerator
   * extension[algorithmVersion] 1.. 
     * valueString // The version of the algorithm used to generate the text
   * extension[language] 1.. 

--- a/input/fsh/terminologies/DosageTextAlgorithm.fsh
+++ b/input/fsh/terminologies/DosageTextAlgorithm.fsh
@@ -2,7 +2,7 @@ CodeSystem: DosageTextAlgorithmCS
 Id: DosageTextAlgorithm
 Title: "Dosage Text Algorithm CodeSystem"
 Description: "Dieses CodeSystem legt die Algorithmen fest, mit denen aus strukturierten Dosierungsangaben automatisch Dosierungsanweisungen in Textform erzeugt werden."
-* #DgmpDosageTextGenerator "Gematik Dosage Text Generator" "Source: https://github.com/hl7germany/medication-ig-de-r4/blob/main/input/content/dosage-to-text.py"
+* #DgMPDosageTextGenerator "Gematik Dosage Text Generator" "Source: https://github.com/hl7germany/medication-ig-de-r4/blob/main/input/content/dosage-to-text.py"
 
 ValueSet: DosageTextAlgorithmVS
 Id: DosageTextAlgorithm

--- a/input/fsh/terminologies/DosageTextAlgorithm.fsh
+++ b/input/fsh/terminologies/DosageTextAlgorithm.fsh
@@ -2,7 +2,7 @@ CodeSystem: DosageTextAlgorithmCS
 Id: DosageTextAlgorithm
 Title: "Dosage Text Algorithm CodeSystem"
 Description: "Dieses CodeSystem legt die Algorithmen fest, mit denen aus strukturierten Dosierungsangaben automatisch Dosierungsanweisungen in Textform erzeugt werden."
-* #GematikDosageTextGenerator "Gematik Dosage Text Generator" "Source: https://github.com/hl7germany/medication-ig-de-r4/blob/main/input/content/dosage-to-text.py"
+* #DgmpDosageTextGenerator "Gematik Dosage Text Generator" "Source: https://github.com/hl7germany/medication-ig-de-r4/blob/main/input/content/dosage-to-text.py"
 
 ValueSet: DosageTextAlgorithmVS
 Id: DosageTextAlgorithm

--- a/scripts/dosage-add-extension.py
+++ b/scripts/dosage-add-extension.py
@@ -24,7 +24,7 @@ def build_extension(dosage_text):
             {
                 "url": "algorithm",
                 "valueCoding": {
-                    "code": "DgmpDosageTextGenerator",
+                    "code": "DgMPDosageTextGenerator",
                     "system": "http://ig.fhir.de/igs/medication/CodeSystem/DosageTextAlgorithm",
                     "version": "1.0.0"
                 }

--- a/scripts/dosage-add-extension.py
+++ b/scripts/dosage-add-extension.py
@@ -24,7 +24,7 @@ def build_extension(dosage_text):
             {
                 "url": "algorithm",
                 "valueCoding": {
-                    "code": "GematikDosageTextGenerator",
+                    "code": "DgmpDosageTextGenerator",
                     "system": "http://ig.fhir.de/igs/medication/CodeSystem/DosageTextAlgorithm",
                     "version": "1.0.0"
                 }

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -5,7 +5,7 @@ import os
 
 __version__ = "1.0.0"
 
-class GematikDosageTextGenerator:
+class DgmpDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
         # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
@@ -249,7 +249,7 @@ def main():
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             dosage = json.load(file)
-        generator = GematikDosageTextGenerator()
+        generator = DgmpDosageTextGenerator()
         result = generator.generate_single_dosage_text(dosage)
         print(result)
     except json.JSONDecodeError as e:

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -5,7 +5,7 @@ import os
 
 __version__ = "1.0.0"
 
-class DgmpDosageTextGenerator:
+class DgMPDosageTextGenerator:
     def generate_single_dosage_text(self, dosage):
         # Nicht unterstützte Felder dürfen nicht angegeben werden
         unsupported_fields = self.get_unsupported_fields(dosage)
@@ -249,7 +249,7 @@ def main():
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             dosage = json.load(file)
-        generator = DgmpDosageTextGenerator()
+        generator = DgMPDosageTextGenerator()
         result = generator.generate_single_dosage_text(dosage)
         print(result)
     except json.JSONDecodeError as e:


### PR DESCRIPTION
This pull request updates the naming of the dosage text generator throughout the codebase and related configuration files. The main change is renaming the class and its references from `GematikDosageTextGenerator` to `DgMPDosageTextGenerator` to ensure consistency and alignment with current terminology.

Naming updates:

* Renamed the class `GematikDosageTextGenerator` to `DgMPDosageTextGenerator` in both `input/content/dosage-to-text.py` and `scripts/dosage-to-text.py`, including all usages in the `main()` function. [[1]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L8-R8) [[2]](diffhunk://#diff-a983fa229370b57d891d8288600c2d5ed4c4b535ed47e5d6d69b5d830f3261b7L252-R252)
* Updated the code reference in the FHIR data type definition in `input/fsh/datatypes/DosageDgMP.fsh` from `GematikDosageTextGenerator` to `DgMPDosageTextGenerator`.
* Changed the code value in the extension builder in `scripts/dosage-add-extension.py` to use `DgMPDosageTextGenerator`.
* Updated the terminology code system in `input/fsh/terminologies/DosageTextAlgorithm.fsh` to reference `DgMPDosageTextGenerator` instead of the old name.