### PR TITLE
fix: correct punctuation in dosage text generation documentation

### DIFF
--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -6,7 +6,7 @@ Diese Seite beschreibt den Algorithmus, wie die strukturierten Dosierinformation
 
 ### Grundlegende Festlegungen
 
-Der generierte Text, der sich aus einer Dosierung ableitet muss im digital gestützten Medikationsprozess (dgMP) immer exakt der strukturierten Darstellung entsprechen. Diese Seite beschreibt die Spezifikation dieses Algorithmus, der in einer [Python Referenzimplementierung](./dosage-to-text.py) umgesetzt wurde.
+Der generierte Text, der sich aus einer Dosierung ableitet, muss im digital gestützten Medikationsprozess (dgMP) immer exakt der strukturierten Darstellung entsprechen. Diese Seite beschreibt die Spezifikation dieses Algorithmus, der in einer [Python Referenzimplementierung](./dosage-to-text.py) umgesetzt wurde.
 Für Informationen wie im dgMP sichergestellt wird, dass der Text an einer Dosierung korrekt ist siehe [Infrastruktur zur Bereitstellung des Textes der Dosierung](./dosierung-text-hinzufuegen.html).
 
 ### Algorithmus zur Textgenerierung


### PR DESCRIPTION
This pull request makes a minor correction to the documentation for the dosage text generation algorithm. The change improves the clarity and correctness of the introductory paragraph by adding a missing comma.

([input/pagecontent/dosierung-textgenerierung.mdL9-R9](diffhunk://#diff-0af679fc9c0455ee310151d6593cd24fd4a8c50408a80cb608b8fbcd846b2344L9-R9))