### PR TITLE
Add note to usage of dosage text script

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -240,7 +240,7 @@ class GematikDosageTextGenerator:
 
 def main():
     if len(sys.argv) < 2:
-        print('Verwendung: python dosage-generator.py <dosage.json>', file=sys.stderr)
+        print('Verwendung: python dosage-to-text.py <dosage.json>', file=sys.stderr)
         sys.exit(1)
     file_path = sys.argv[1]
     if not os.path.exists(file_path):

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -9,6 +9,17 @@ Diese Seite beschreibt den Algorithmus, wie die strukturierten Dosierinformation
 Der generierte Text, der sich aus einer Dosierung ableitet, muss im digital gestützten Medikationsprozess (dgMP) immer exakt der strukturierten Darstellung entsprechen. Diese Seite beschreibt die Spezifikation dieses Algorithmus, der in einer [Python Referenzimplementierung](./dosage-to-text.py) umgesetzt wurde.
 Für Informationen wie im dgMP sichergestellt wird, dass der Text an einer Dosierung korrekt ist siehe [Infrastruktur zur Bereitstellung des Textes der Dosierung](./dosierung-text-hinzufuegen.html).
 
+#### Verwendung der Python Referenzimplementierung
+Das Skript kann genau eine FHIR-Dosage Instanz auswerten und den Text beschreiben. Hierzu wird die gewünschte FHIR-Dosage Instanz bspw. als JSON-Datei übergeben. Die Anwendung erfolgt über die Kommandozeile:
+
+```bash
+python path-to/dosage-to-text.py <dosage.json>
+```
+
+Das Skript liest die Datei `<dosage.json>`, prüft die Felder gemäß den oben beschriebenen Regeln und gibt den generierten Dosierungstext auf der Konsole aus. Bei nicht unterstützten Feldern wird eine entsprechende Fehlermeldung ausgegeben.
+
+Die Ausgabe ist entweder der generierte Dosierungstext oder eine Fehlermeldung mit Angabe der nicht unterstützten Felder.
+
 ### Algorithmus zur Textgenerierung
 
 Das Skript unterstützt aktuell nur eine Teilmenge der möglichen Felder für Dosierungsangaben.  

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -240,7 +240,7 @@ class GematikDosageTextGenerator:
 
 def main():
     if len(sys.argv) < 2:
-        print('Verwendung: python dosage-generator.py <dosage.json>', file=sys.stderr)
+        print('Verwendung: python dosage-to-text.py <dosage.json>', file=sys.stderr)
         sys.exit(1)
     file_path = sys.argv[1]
     if not os.path.exists(file_path):


### PR DESCRIPTION
This pull request introduces improvements to both the documentation and the command-line interface for the dosage-to-text Python script. The main focus is on clarifying usage instructions and ensuring consistency between the script name and its documentation.

Documentation improvements:

* Added a new section in `dosierung-textgenerierung.md` detailing how to use the Python reference implementation, including example command-line usage and expected output/behavior.

Command-line interface consistency:

* Updated the usage message in the `main()` function of both `input/content/dosage-to-text.py` and `scripts/dosage-to-text.py` to reference the correct script name (`dosage-to-text.py` instead of the outdated `dosage-generator.py`).