### PR TITLE
feat: set comparator on boundsDuration to 0..0 in TimingDgMP

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -28,6 +28,7 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
     * system 1..1 MS
     * unit 1..1 MS
     * value 1..1 MS
+    * comparator 0..0
   * frequency 1..1 MS
   * period 1..1 MS
   * periodUnit 1..1 MS


### PR DESCRIPTION
This pull request makes a small adjustment to the `TimingDgMP` datatype definition. The change ensures that the `comparator` field is explicitly disallowed in this context.

* Added a constraint to the `comparator` field, setting its cardinality to `0..0` to prevent its use in `TimingDgMP`.