### PR TITLE
Add all 0..0 fields to deny lists in text generation script Hdb 656

### DIFF
--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -50,14 +50,16 @@ class DgMPDosageTextGenerator:
     
     def get_unsupported_fields(self, dosage):
         deny_dosage_fields = {
+            "sequence", "patientInstruction",
             "asNeededBoolean", "asNeededCodeableConcept", "method", "route", "site",
             "additionalInstruction", "maxDosePerPeriod", "maxDosePerAdministration", "maxDosePerLifetime"
         }
-        deny_timing_fields = {"event"}
+        deny_timing_fields = {"event", "code"}
         deny_timing_repeat_fields = {
-            "count", "countMax", "boundsPeriod", "boundsRange", "offset", "frequencyMax", "periodMax"
+            "count", "countMax", "boundsPeriod", "boundsRange", "offset", "frequencyMax", "periodMax",
+            "duration", "durationMax", "durationUnit"
         }
-        deny_doseAndRate_subfields = {"doseRange", "rateQuantity", "rateRange", "rateRatio"}
+        deny_doseAndRate_subfields = {"doseRange", "rateQuantity", "rateRange", "rateRatio", "type"}
 
         unsupported = set()
         

--- a/input/content/dosage-to-text.py
+++ b/input/content/dosage-to-text.py
@@ -81,18 +81,18 @@ class DgMPDosageTextGenerator:
         for key in repeat.keys():
             if key in deny_timing_repeat_fields:
                 unsupported.add(f"timing.repeat.{key}")
-            
-    # only allow specific 'when' codes
-    supported_when = {"MORN", "NOON", "EVE", "NIGHT"}
-    when_list = repeat.get("when", [])
-    invalid_when = []
-    for w in when_list:
-        w_up = str(w).upper()
-        if w_up not in supported_when:
-            invalid_when.append(w_up)
-    # add each invalid code separately so they all appear in the error message
-    for w_up in sorted(set(invalid_when)):
-        unsupported.add(f"timing.repeat.when={w_up}")
+        
+        # only allow specific 'when' codes
+        supported_when = {"MORN", "NOON", "EVE", "NIGHT"}
+        when_list = repeat.get("when", [])
+        invalid_when = []
+        for w in when_list:
+            w_up = str(w).upper()
+            if w_up not in supported_when:
+                invalid_when.append(w_up)
+        # add each invalid code separately so they all appear in the error message
+        for w_up in sorted(set(invalid_when)):
+            unsupported.add(f"timing.repeat.when={w_up}")
 
         return list(unsupported)
 

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -50,14 +50,16 @@ class DgMPDosageTextGenerator:
     
     def get_unsupported_fields(self, dosage):
         deny_dosage_fields = {
+            "sequence", "patientInstruction",
             "asNeededBoolean", "asNeededCodeableConcept", "method", "route", "site",
             "additionalInstruction", "maxDosePerPeriod", "maxDosePerAdministration", "maxDosePerLifetime"
         }
-        deny_timing_fields = {"event"}
+        deny_timing_fields = {"event", "code"}
         deny_timing_repeat_fields = {
-            "count", "countMax", "boundsPeriod", "boundsRange", "offset", "frequencyMax", "periodMax"
+            "count", "countMax", "boundsPeriod", "boundsRange", "offset", "frequencyMax", "periodMax",
+            "duration", "durationMax", "durationUnit"
         }
-        deny_doseAndRate_subfields = {"doseRange", "rateQuantity", "rateRange", "rateRatio"}
+        deny_doseAndRate_subfields = {"doseRange", "rateQuantity", "rateRange", "rateRatio", "type"}
 
         unsupported = set()
         

--- a/scripts/dosage-to-text.py
+++ b/scripts/dosage-to-text.py
@@ -81,18 +81,18 @@ class DgMPDosageTextGenerator:
         for key in repeat.keys():
             if key in deny_timing_repeat_fields:
                 unsupported.add(f"timing.repeat.{key}")
-            
-    # only allow specific 'when' codes
-    supported_when = {"MORN", "NOON", "EVE", "NIGHT"}
-    when_list = repeat.get("when", [])
-    invalid_when = []
-    for w in when_list:
-        w_up = str(w).upper()
-        if w_up not in supported_when:
-            invalid_when.append(w_up)
-    # add each invalid code separately so they all appear in the error message
-    for w_up in sorted(set(invalid_when)):
-        unsupported.add(f"timing.repeat.when={w_up}")
+        
+        # only allow specific 'when' codes
+        supported_when = {"MORN", "NOON", "EVE", "NIGHT"}
+        when_list = repeat.get("when", [])
+        invalid_when = []
+        for w in when_list:
+            w_up = str(w).upper()
+            if w_up not in supported_when:
+                invalid_when.append(w_up)
+        # add each invalid code separately so they all appear in the error message
+        for w_up in sorted(set(invalid_when)):
+            unsupported.add(f"timing.repeat.when={w_up}")
 
         return list(unsupported)
 


### PR DESCRIPTION
This pull request updates the logic for identifying unsupported fields in the dosage-to-text conversion scripts. The main changes expand the lists of fields that are considered unsupported, which should improve the accuracy and robustness of dosage text generation.

**Unsupported fields expansion:**

* Added `"sequence"` and `"patientInstruction"` to the set of denied dosage fields in both `input/content/dosage-to-text.py` and `scripts/dosage-to-text.py`.
* Added `"code"` to the set of denied timing fields in both files.
* Added `"duration"`, `"durationMax"`, and `"durationUnit"` to the set of denied timing repeat fields in both files.
* Added `"type"` to the set of denied doseAndRate subfields in both files.