### PR TITLE
feat: add invariant for timing bounds unit string consistency with UCUM codes

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -76,6 +76,45 @@ and
 ((dayOfWeek.empty() and (when.exists() or timeOfDay.exists())) implies periodUnit = 'd')"
 Severity: #error
 
+Invariant: TimingBoundsUnitMatchesCode
+Description: "boundsDuration.unit muss zur UCUM boundsDuration.code passen (z. B. 'Woche(n)' nur mit code='wk')."
+Expression: "repeat.bounds.ofType(Duration).exists().not() or (
+  (
+    repeat.bounds.ofType(Duration).code = 'd'
+    implies 
+    (
+      repeat.bounds.ofType(Duration).unit = 'Tag(e)' or
+      repeat.bounds.ofType(Duration).unit = 'Tag' or
+      repeat.bounds.ofType(Duration).unit = 'Tage'
+    )
+  ) and (
+    repeat.bounds.ofType(Duration).code = 'wk'
+    implies 
+    (
+      repeat.bounds.ofType(Duration).unit = 'Woche(n)' or
+      repeat.bounds.ofType(Duration).unit = 'Woche' or
+      repeat.bounds.ofType(Duration).unit = 'Wochen'
+    )
+  ) and (
+    repeat.bounds.ofType(Duration).code = 'mo'
+    implies 
+    (
+      repeat.bounds.ofType(Duration).unit = 'Monat(e)' or
+      repeat.bounds.ofType(Duration).unit = 'Monat' or
+      repeat.bounds.ofType(Duration).unit = 'Monate'
+    )
+  ) and (
+    repeat.bounds.ofType(Duration).code = 'a'
+    implies 
+    (
+      repeat.bounds.ofType(Duration).unit = 'Jahr(e)' or
+      repeat.bounds.ofType(Duration).unit = 'Jahr' or
+      repeat.bounds.ofType(Duration).unit = 'Jahre'
+    )
+  )
+)"
+Severity: #error
+
 Invariant: TimingOnlyOneType
 Description: "Only one kind of Timing is allowed. Current allowed timings: 4-Scheme, TimeOfDay, DayOfWeek, Interval, DayOfWeek and Time/4-Schema, Interval and Time/4-Schema"
 Expression: "/* DayOfWeek */


### PR DESCRIPTION
This pull request adds a new invariant to the `TimingDgMP` datatype definition to ensure better data consistency between UCUM codes and their corresponding units in the `repeat.bounds` attribute.

Validation improvements:

* Added the `TimingBoundsUnitMatchesCode` invariant to enforce that the `boundsDuration.unit` matches the UCUM `boundsDuration.code` (e.g., only 'Woche(n)' with code='wk', 'Tag(e)' with code='d', etc.), improving semantic correctness of timing data.