### PR TITLE
feat: fix TimingBoundsUnitMatchesCode invariant and add examples

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -80,38 +80,38 @@ Severity: #error
 
 Invariant: TimingBoundsUnitMatchesCode
 Description: "boundsDuration.unit muss zur UCUM boundsDuration.code passen (z. B. 'Woche(n)' nur mit code='wk')."
-Expression: "repeat.bounds.ofType(Duration).exists().not() or (
+Expression: "bounds.ofType(Duration).exists().not() or (
   (
-    repeat.bounds.ofType(Duration).code = 'd'
+    bounds.ofType(Duration).code = 'd'
     implies 
     (
-      repeat.bounds.ofType(Duration).unit = 'Tag(e)' or
-      repeat.bounds.ofType(Duration).unit = 'Tag' or
-      repeat.bounds.ofType(Duration).unit = 'Tage'
+      bounds.ofType(Duration).unit = 'Tag(e)' or
+      bounds.ofType(Duration).unit = 'Tag' or
+      bounds.ofType(Duration).unit = 'Tage'
     )
   ) and (
-    repeat.bounds.ofType(Duration).code = 'wk'
+    bounds.ofType(Duration).code = 'wk'
     implies 
     (
-      repeat.bounds.ofType(Duration).unit = 'Woche(n)' or
-      repeat.bounds.ofType(Duration).unit = 'Woche' or
-      repeat.bounds.ofType(Duration).unit = 'Wochen'
+      bounds.ofType(Duration).unit = 'Woche(n)' or
+      bounds.ofType(Duration).unit = 'Woche' or
+      bounds.ofType(Duration).unit = 'Wochen'
     )
   ) and (
-    repeat.bounds.ofType(Duration).code = 'mo'
+    bounds.ofType(Duration).code = 'mo'
     implies 
     (
-      repeat.bounds.ofType(Duration).unit = 'Monat(e)' or
-      repeat.bounds.ofType(Duration).unit = 'Monat' or
-      repeat.bounds.ofType(Duration).unit = 'Monate'
+      bounds.ofType(Duration).unit = 'Monat(e)' or
+      bounds.ofType(Duration).unit = 'Monat' or
+      bounds.ofType(Duration).unit = 'Monate'
     )
   ) and (
-    repeat.bounds.ofType(Duration).code = 'a'
+    bounds.ofType(Duration).code = 'a'
     implies 
     (
-      repeat.bounds.ofType(Duration).unit = 'Jahr(e)' or
-      repeat.bounds.ofType(Duration).unit = 'Jahr' or
-      repeat.bounds.ofType(Duration).unit = 'Jahre'
+      bounds.ofType(Duration).unit = 'Jahr(e)' or
+      bounds.ofType(Duration).unit = 'Jahr' or
+      bounds.ofType(Duration).unit = 'Jahre'
     )
   )
 )"

--- a/input/fsh/examples/constraint_examples_bounds_unit_match.fsh
+++ b/input/fsh/examples/constraint_examples_bounds_unit_match.fsh
@@ -1,0 +1,36 @@
+// Examples for TimingBoundsUnitMatchesCode constraint
+
+Instance: Valid-Dosage-C-TimingBoundsUnitMatchesCode-01-of-02
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Valid boundsDuration unit/code match"
+Description: "boundsDuration.code 'wk' with unit 'Woche(n)'"
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+    * boundsDuration = 3 $ucum#wk "Woche(n)"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+
+Instance: Invalid-Dosage-C-TimingBoundsUnitMatchesCode-02-of-02
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid boundsDuration unit/code mismatch"
+Description: "boundsDuration.code 'wk' with unit 'Tag(e)'"
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+    * boundsDuration = 3 $ucum#wk "Tag(e)"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+

--- a/input/includes/dosage-constraint-TimingBoundsUnitMatchesCode-examples.md
+++ b/input/includes/dosage-constraint-TimingBoundsUnitMatchesCode-examples.md
@@ -1,0 +1,4 @@
+| File | generated dosage instruction text | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationRequest-Invalid-Dosage-C-TimingBoundsUnitMatchesCode-02-of-02](./MedicationRequest-Invalid-Dosage-C-TimingBoundsUnitMatchesCode-02-of-02.html) | für 3 Tag(e) alle 2 Tage: je 1 Stück | 1 Stück |  |  | 1 | 2 | d |  |  |  | {'system': 'http://unitsofmeasure.org', 'value': 3, 'code': 'wk', 'unit': 'Tag(e)'} |
+| [MedicationRequest-Valid-Dosage-C-TimingBoundsUnitMatchesCode-01-of-02](./MedicationRequest-Valid-Dosage-C-TimingBoundsUnitMatchesCode-01-of-02.html) | für 3 Woche(n) alle 2 Tage: je 1 Stück | 1 Stück |  |  | 1 | 2 | d |  |  |  | {'system': 'http://unitsofmeasure.org', 'value': 3, 'code': 'wk', 'unit': 'Woche(n)'} |


### PR DESCRIPTION
This pull request refines the implementation and documentation of the `TimingBoundsUnitMatchesCode` constraint for the `TimingDgMP` datatype. The main focus is on improving constraint logic and providing clear example instances and documentation to illustrate valid and invalid cases.

Constraint logic improvement:

* Updated the FSH invariant expression in `TimingDgMP.fsh` to reference `bounds.ofType(Duration)` directly instead of `repeat.bounds.ofType(Duration)`, ensuring correct constraint evaluation and simplifying the logic.

Documentation and examples:

* Added two example instances to `constraint_examples_bounds_unit_match.fsh` demonstrating a valid and an invalid match between `boundsDuration.code` and `boundsDuration.unit`, making the constraint easier to understand and test.
* Included a markdown table in `dosage-constraint-TimingBoundsUnitMatchesCode-examples.md` summarizing the example instances, showing how the constraint applies to real dosage instructions.