### PR TITLE
fix: update dosage unit from 'Tablette' to 'Stück' for consistency across documentation

### DIFF
--- a/input/pagecontent/dosierung-dgmp.md
+++ b/input/pagecontent/dosierung-dgmp.md
@@ -20,7 +20,7 @@ In der aktuellen Ausbaustufe und im Kontext dgMP ist die Verwendung von `Dosage.
 
 #### Strukturierte Angabe der Einheit
 
-Für die Berechnung der Reichweite einer Medikation ist es erforderlich, dass Dosierungseinheiten (z.B. „1 Tablette“) strukturiert über ein Codesystem angegeben werden.  
+Für die Berechnung der Reichweite einer Medikation ist es erforderlich, dass Dosierungseinheiten (z.B. „1 Stück) strukturiert über ein Codesystem angegeben werden.  
 Dafür wird das ValueSet `KBV_VS_SFHIR_BMP_DOSIEREINHEIT` genutzt.
 
 #### Beispiele
@@ -84,10 +84,10 @@ Sobald diesbezüglich eine Entscheidung getroffen wurde, wird die Planung zur zw
 
 | Ergänzung / Alternative                                  | Beispiel                                               |
 |----------------------------------------------------------|--------------------------------------------------------|
-| Ungefähre Gesamtdauer                                    | Täglich 1 Tablette für 1–2 Wochen                      |
-| Start- und Enddatum                                      | Täglich 1 Tablette vom 01.12.2025 bis zum 15.12.2025   |
-| Gesamtzahl an Anwendungen bis zum Therapieabschluss      | Täglich 1 Tablette, insgesamt 20 Stück                 |
-| Ungefähre Dosierung                                      | Täglich 1–2 Tabletten                                  |
+| Ungefähre Gesamtdauer                                    | Täglich 1 Stück für 1–2 Wochen                      |
+| Start- und Enddatum                                      | Täglich 1 Stück vom 01.12.2025 bis zum 15.12.2025   |
+| Gesamtzahl an Anwendungen bis zum Therapieabschluss      | Täglich 1 Stück, insgesamt 20 Stück                 |
+| Ungefähre Dosierung                                      | Täglich 1–2 Stück                                  |
 
 **Wertelisten & Ereignisbezug**
 
@@ -104,8 +104,8 @@ Sobald diesbezüglich eine Entscheidung getroffen wurde, wird die Planung zur zw
 
 | Übergeordnete Beziehung zwischen bestehenden Schemata           | Beispiel                                                                                                 |
 |-----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| Änderung von Dosis oder Anwendungshäufigkeit im Zeitverlauf     | Täglich 1 Tablette morgens für 1 Woche. Anschließend täglich 2 Tabletten morgens für 1 Woche. (Einschleichen) |
-| Kombination verschiedener Anwendungsintervalle                  | Abwechselnd: Jeden zweiten Tag 1 Tablette morgens und jeden zweiten Tag 2 Tabletten morgens              |
+| Änderung von Dosis oder Anwendungshäufigkeit im Zeitverlauf     | Täglich 1 Stück morgens für 1 Woche. Anschließend täglich 2 Stück morgens für 1 Woche. (Einschleichen) |
+| Kombination verschiedener Anwendungsintervalle                  | Abwechselnd: Jeden zweiten Tag 1 Stück morgens und jeden zweiten Tag 2 Stück morgens              |
 
 ##### Beispiele für komplexe Beziehungen zwischen Arzneimitteln
 

--- a/input/pagecontent/dosierung-rahmenbedingungen.md
+++ b/input/pagecontent/dosierung-rahmenbedingungen.md
@@ -21,23 +21,23 @@ Im Kontext des dgMP sorgt die [Infrastruktur zur Bereitstellung des Dosierungste
 
 ### Verwendung mehrerer Dosages
 
-Jede `Dosage`-Instanz beschreibt eine Kombination aus Einnahmerhythmus (z.B. „3x täglich“) und der zugehörigen Dosis pro Einnahmeereignis (z.B. „2 Tabletten“). Der Einnahmerhythmus wird in `Dosage.timing` abgebildet.
+Jede `Dosage`-Instanz beschreibt eine Kombination aus Einnahmerhythmus (z.B. „3x täglich“) und der zugehörigen Dosis pro Einnahmeereignis (z.B. „2 Stück“). Der Einnahmerhythmus wird in `Dosage.timing` abgebildet.
 
 Wichtig:
 - Jede `Dosage`-Instanz bildet *nur ein Dosierschema* ab.
-- Für verschiedene Dosierungen innerhalb desselben Schemas (z.B. morgens 1 Tablette, abends 2 Tabletten) sind separate `Dosage`-Instanzen erforderlich.
+- Für verschiedene Dosierungen innerhalb desselben Schemas (z.B. morgens 1 Stück, abends 2 Stück) sind separate `Dosage`-Instanzen erforderlich.
 
 **Beispiel:**
 
-Ein Patient soll morgens 1 Tablette und abends 2 Tabletten einnehmen.
+Ein Patient soll morgens 1 Stück und abends 2 Stück einnehmen.
 
 - Es werden zwei `Dosage`-Instanzen erstellt:
     1. Erste Dosage:  
         - `Dosage.timing`: morgens  
-        - `Dosage.doseAndRate`: 1 Tablette
+        - `Dosage.doseAndRate`: 1 Stück
     2. Zweite Dosage:  
         - `Dosage.timing`: abends  
-        - `Dosage.doseAndRate`: 2 Tabletten
+        - `Dosage.doseAndRate`: 2 Stück
 
 Jede dieser Instanzen beschreibt ein eigenes Dosierschema, auch wenn sie im selben Medikationsauftrag stehen.
 Eine Instanz dieser Dosierung ist im Beispiel [MedicationRequest-Example-MR-Dosage-1010](./MedicationRequest-Example-MR-Dosage-1010.html) einzusehen.
@@ -50,6 +50,6 @@ In der aktuellen Ausbaustufe und im Kontext dgMP ist die Verwendung von `Dosage.
 
 ### Strukturierte Angabe der Einheit
 
-Für die Berechnung der Reichweite einer Medikation ist es erforderlich, dass Dosierungseinheiten (z.B. „1 Tablette“) strukturiert über ein Codesystem angegeben werden.  
+Für die Berechnung der Reichweite einer Medikation ist es erforderlich, dass Dosierungseinheiten (z.B. „1 Stück“) strukturiert über ein Codesystem angegeben werden.  
 Dafür steht ein eingeschränktes ValueSet (`DosageDoseQuantityDE` bzw. `DosageDoseQuantityDGMP`) zur Verfügung, das alle zulässigen Dosiereinheiten enthält.  
 Die strukturierte Angabe der Einheit bildet die Grundlage für mögliche Reichweitenberechnungen und fördert die Interoperabilität.

--- a/input/pagecontent/dosierung-rahmenvorgaben.md
+++ b/input/pagecontent/dosierung-rahmenvorgaben.md
@@ -16,7 +16,7 @@ Die Extension [GeneratedDosageInstructions](./StructureDefinition-GeneratedDosag
 
 
 - **Konstante Dosierung:** Bei gleichbleibender Dosierungsstärke innerhalb eines Schemas ist eine einzige `Dosage`-Instanz ausreichend.
-- **Variable Dosierung:** Wechselt die Dosierungsstärke (z.B. morgens 1 Tablette, abends 2 Tabletten), muss für jede Dosierungsvariation eine separate `Dosage`-Instanz erstellt werden.
+- **Variable Dosierung:** Wechselt die Dosierungsstärke (z.B. morgens 1 Stück, abends 2 Stück), muss für jede Dosierungsvariation eine separate `Dosage`-Instanz erstellt werden.
 
 Folgende FHIR Ressourcen unterstützen die Angabe von Dosierungen:
 - [MedicationRequest](https://hl7.org/fhir/R4/medicationrequest.html)
@@ -27,19 +27,19 @@ Folgende FHIR Ressourcen unterstützen die Angabe von Dosierungen:
 
 Diese Ressourcen ermöglichen die *mehrfache* Angabe einer [FHIR Ressource Dosage](https://hl7.org/fhir/R4/dosage.html) (..*).
 
-Eine Dosage-Instanz kann dabei nur ein Timing Objekt und eine Angabe der Dosierung tragen. Daher kann für eine Art der Dosierung (z.B. 1 Tablette) das Timing variabel definiert werden. Unterschiedliche Dosierungen erzeugen jeweils eine eigene Dosage Instanz.
+Eine Dosage-Instanz kann dabei nur ein Timing Objekt und eine Angabe der Dosierung tragen. Daher kann für eine Art der Dosierung (z.B. 1 Stück) das Timing variabel definiert werden. Unterschiedliche Dosierungen erzeugen jeweils eine eigene Dosage Instanz.
 
 **Beispiele:**
 
-- 1-0-1-0 soll in einer Dosage Instanz mit `timing.repeat.when = MORN, EVE` und `doseAndRate.doseQuantity = 1 Tablette` angegeben werden
+- 1-0-1-0 soll in einer Dosage Instanz mit `timing.repeat.when = MORN, EVE` und `doseAndRate.doseQuantity = 1 Stück` angegeben werden
 - 1-0-2-0 benötigt zwei Dosage Instanzen:
-  - erste Dosage Instanz: `timing.repeat.when = MORN` und `doseAndRate.doseQuantity = 1 Tablette`
-  - zweite Dosage Instanz: `timing.repeat.when = EVE` und `doseAndRate.doseQuantity = 2 Tabletten`
+  - erste Dosage Instanz: `timing.repeat.when = MORN` und `doseAndRate.doseQuantity = 1 Stück`
+  - zweite Dosage Instanz: `timing.repeat.when = EVE` und `doseAndRate.doseQuantity = 2 Stück`
 
-Für eine Dosierung (z.B. 1 Tablette) kann ein komplexes Zeitschema angegeben werden, wenn zu jedem der eintretenden Zeitpunkte diese Dosierung einzunehmen ist.
+Für eine Dosierung (z.B. 1 Stück) kann ein komplexes Zeitschema angegeben werden, wenn zu jedem der eintretenden Zeitpunkte diese Dosierung einzunehmen ist.
 
-- 1 Tablette Montags, Mittwochs, Samstags jeweils 08:00 und 20:00:
-  - `doseAndRate.doseQuantity = 1 Tablette`
+- 1 Stück Montags, Mittwochs, Samstags jeweils 08:00 und 20:00:
+  - `doseAndRate.doseQuantity = 1 Stück`
   - `timing.repeat.dayOfWeek = mon, wed, sat`
   - `timing.repeat.timeOfDay = 08:00:00, 20:00:00`
 
@@ -47,4 +47,4 @@ wird in der selben Dosage Instanz abgebildet.
 
 ## Strukturierte Angabe der Einheit
 
-Für die Berechnung der Reichweite einer Medikation ist es erforderlich, dass Dosierungseinheiten (z.B. „1 Tablette“) strukturiert und semantisch kodiert angegeben werden. Hierfür wurde das  ValueSet `DosageDoseQuantityDEVS` erstellt.
+Für die Berechnung der Reichweite einer Medikation ist es erforderlich, dass Dosierungseinheiten (z.B. „1 Stück“) strukturiert und semantisch kodiert angegeben werden. Hierfür wurde das  ValueSet `DosageDoseQuantityDEVS` erstellt.

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -97,7 +97,7 @@ Im folgenden wird für jedes Element ein Beispiel angegeben, wie die Überführu
 
 | Element                       | Darstellung (Deutsch)         | Beispiel(e)           |
 |-------------------------------|-------------------------------|-----------------------|
-| **doseAndRate.doseQuantity**  | `{value} {unit}`              | `50 Milligramm`<br>`2 Tabletten` |
+| **doseAndRate.doseQuantity**  | `{value} {unit}`              | `50 Milligramm`<br>`2 Stück` |
 
 #### Timing
 

--- a/input/pagecontent/schema-freitext.md
+++ b/input/pagecontent/schema-freitext.md
@@ -8,7 +8,7 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 | Beispiel    | Beipspiel Datei |
 | -------- | ------- |
-| 2 Tabletten morgens zum Frühstück  | [Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html)    |
+| 2 Stück morgens zum Frühstück  | [Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html)    |
 
 ### Angabe und Erkennung der Dosierart
 

--- a/input/pagecontent/schema-intervall-kombination.md
+++ b/input/pagecontent/schema-intervall-kombination.md
@@ -10,9 +10,9 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 | Beispiel    | Beipspiel Datei |
 | -------- | ------- |
-| Jeden 2. Tag 1 Tablette um 08:00 Uhr und 2 Tabletten um 18:00 Uhr  | [Example-MR-Dosage-comb-interval-1](./MedicationRequest-Example-MR-Dosage-comb-interval-1.html)    |  |
-| 1 x pro Woche 1 Tablette morgens  | [Example-MR-Dosage-comb-interval-2](./MedicationRequest-Example-MR-Dosage-comb-interval-2.html)    |
-| Jeden 2. Tag 1 Tablette um 08:00 Uhr und jeden 2. Tag 1 Tablette um 08:00 Uhr  | [Example-MR-Dosage-comb-interval-3](./MedicationRequest-Example-MR-Dosage-comb-interval-3.html)    |
+| Jeden 2. Tag 1 Stück um 08:00 Uhr und 2 Stück um 18:00 Uhr  | [Example-MR-Dosage-comb-interval-1](./MedicationRequest-Example-MR-Dosage-comb-interval-1.html)    |  |
+| 1 x pro Woche 1 Stück morgens  | [Example-MR-Dosage-comb-interval-2](./MedicationRequest-Example-MR-Dosage-comb-interval-2.html)    |
+| Jeden 2. Tag 1 Stück um 08:00 Uhr und jeden 2. Tag 1 Stück um 08:00 Uhr  | [Example-MR-Dosage-comb-interval-3](./MedicationRequest-Example-MR-Dosage-comb-interval-3.html)    |
 
 ### Angabe und Erkennung der Dosierart 
 

--- a/input/pagecontent/schema-intervall.md
+++ b/input/pagecontent/schema-intervall.md
@@ -12,11 +12,11 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 | Beispiel    | Beipspiel Datei |
 | -------- | ------- |
-| 1 Tablette alle 8 Tage  | [Example-MR-Dosage-interval-8d](./MedicationRequest-Example-MR-Dosage-interval-8d.html)    |  |
-| 1 Tablette alle 2 Wochen  | [Example-MR-Dosage-interval-2wk](./MedicationRequest-Example-MR-Dosage-interval-2wk.html)    |
-| 4 x 1 Tablette pro Tag  | [Example-MR-Dosage-interval-4times-d](./MedicationRequest-Example-MR-Dosage-interval-4times-d.html)    |
-| Alle 3 Tage 1 Tablette  | [Example-MR-Dosage-interval-3d](./MedicationRequest-Example-MR-Dosage-interval-3d.html)    |
-| Alle 2 Tage 2 Tabletten für 6 Wochen  | [Example-MR-Dosage-interval-2d-bound](./MedicationRequest-Example-MR-Dosage-interval-2d-bound.html)    |
+| 1 Stück alle 8 Tage  | [Example-MR-Dosage-interval-8d](./MedicationRequest-Example-MR-Dosage-interval-8d.html)    |  |
+| 1 Stück alle 2 Wochen  | [Example-MR-Dosage-interval-2wk](./MedicationRequest-Example-MR-Dosage-interval-2wk.html)    |
+| 4 x 1 Stück pro Tag  | [Example-MR-Dosage-interval-4times-d](./MedicationRequest-Example-MR-Dosage-interval-4times-d.html)    |
+| Alle 3 Tage 1 Stück  | [Example-MR-Dosage-interval-3d](./MedicationRequest-Example-MR-Dosage-interval-3d.html)    |
+| Alle 2 Tage 2 Stück für 6 Wochen  | [Example-MR-Dosage-interval-2d-bound](./MedicationRequest-Example-MR-Dosage-interval-2d-bound.html)    |
 
 ### Angabe und Erkennung der Dosierart
 

--- a/input/pagecontent/schema-tageszeit.md
+++ b/input/pagecontent/schema-tageszeit.md
@@ -51,7 +51,7 @@ Soll das Arzneimittel in derselben Dosierung zu mehreren Tageszeiten angewandt w
 
 Beispiel:
 - Dosage.timing.repeat.when = #MORN, #EVE
-- Dosage.doseAndRate.doseQuantity = 1 Tablette
-bedeutet, dass eine Tablette morgens und abends einzunehmen ist.
+- Dosage.doseAndRate.doseQuantity = 1 Stück
+bedeutet, dass eine Stück morgens und abends einzunehmen ist.
 
 Lesende Systeme werten entsprechend auch `Dosage.timing.repeat` aus. Wenn nur .when angegeben ist, ist dem Nutzer das 4-er Schema anzuzeigen.

--- a/input/pagecontent/schema-uhrzeit.md
+++ b/input/pagecontent/schema-uhrzeit.md
@@ -13,11 +13,11 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 
 | Beispiel    | Beipspiel Datei |
 | -------- | ------- |
-| 1 Tablette um 08:00 Uhr | [Example-MR-Dosage-tod-1t-8am](./MedicationRequest-Example-MR-Dosage-tod-1t-8am.html)    |
-| 1 Tablette mit unsortierten Zeiten | [Example-MR-Dosage-tod-unsorted](./MedicationRequest-Example-MR-Dosage-tod-unsorted.html)    |
-| 2 Tablette um 12:00 Uhr | [Example-MR-Dosage-tod-2-12am](./MedicationRequest-Example-MR-Dosage-tod-2-12am.html)     |
-| 8 Uhr 2 Tabletten - 11 Uhr 1 Tablette - 14 Uhr 1 Tablette - 17 Uhr 1 Tablette - 20 Uhr 1 Tablette - 23 Uhr 1 Tablette    | [Example-MR-Dosage-tod-multi](./MedicationRequest-Example-MR-Dosage-tod-multi.html)    |
-| 8 Uhr 2 Tabletten - 11 Uhr 1 Tablette - 14 Uhr 1 Tablette - 17 Uhr 1 Tablette - 20 Uhr 1 Tablette - 23 Uhr 1 Tablette, für 10 Tage    | [Example-MR-Dosage-tod-multi-bound](./MedicationRequest-Example-MR-Dosage-tod-multi-bound.html)    |
+| 1 Stück um 08:00 Uhr | [Example-MR-Dosage-tod-1t-8am](./MedicationRequest-Example-MR-Dosage-tod-1t-8am.html)    |
+| 1 Stück mit unsortierten Zeiten | [Example-MR-Dosage-tod-unsorted](./MedicationRequest-Example-MR-Dosage-tod-unsorted.html)    |
+| 2 Stück um 12:00 Uhr | [Example-MR-Dosage-tod-2-12am](./MedicationRequest-Example-MR-Dosage-tod-2-12am.html)     |
+| 8 Uhr 2 Stück - 11 Uhr 1 Stück - 14 Uhr 1 Stück - 17 Uhr 1 Stück - 20 Uhr 1 Stück - 23 Uhr 1 Stück    | [Example-MR-Dosage-tod-multi](./MedicationRequest-Example-MR-Dosage-tod-multi.html)    |
+| 8 Uhr 2 Stück - 11 Uhr 1 Stück - 14 Uhr 1 Stück - 17 Uhr 1 Stück - 20 Uhr 1 Stück - 23 Uhr 1 Stück, für 10 Tage    | [Example-MR-Dosage-tod-multi-bound](./MedicationRequest-Example-MR-Dosage-tod-multi-bound.html)    |
 
 ### Angabe und Erkennung der Dosierart
 
@@ -48,7 +48,7 @@ Soll das Arzneimittel in derselben Dosierung zu mehreren Uhrzeiten angewandt wer
 
 Beispiel:
 - Dosage.timing.repeat.timeOfDay` = "08:00:00", "12:00:00"
-- Dosage.doseAndRate.doseQuantity = 1 Tablette
-bedeutet, dass eine Tablette jeweils um 08:00 und um 12:00 einzunehmen ist.
+- Dosage.doseAndRate.doseQuantity = 1 Stück
+bedeutet, dass eine Stück jeweils um 08:00 und um 12:00 einzunehmen ist.
 
 Lesende Systeme werten entsprechend auch `Dosage.timing.repeat` aus. Wenn nur .timeOfDay angegeben ist, ist dem Nutzer anzuzeigen, dass die Dosierung nach Uhrzeizen definiert ist.

--- a/input/pagecontent/schema-wochentag-kombination.md
+++ b/input/pagecontent/schema-wochentag-kombination.md
@@ -17,7 +17,7 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 | Montags und Freitags 1-0-1-0  | [Example-MR-Dosage-comb-dayofweek-1](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-1.html)    |  |
 | Montags und Freitags 1-0-2-0  | [Example-MR-Dosage-comb-dayofweek-2](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-2.html)    |
 | Unsortierte Wochentage  | [Example-MR-Dosage-comb-dayofweek-unsorted](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-unsorted.html)    |
-| Montags und Freitags 1 Tablette um 08:00 Uhr und 2 Tabletten um 10:00 Uhr – für 3 Wochen  | [Example-MR-Dosage-comb-dayofweek-3](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-3.html)    |
+| Montags und Freitags 1 Stück um 08:00 Uhr und 2 Stück um 10:00 Uhr – für 3 Wochen  | [Example-MR-Dosage-comb-dayofweek-3](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-3.html)    |
 
 ### Angabe und Erkennung der Dosierart 
 

--- a/input/pagecontent/schema-wochentag.md
+++ b/input/pagecontent/schema-wochentag.md
@@ -17,10 +17,10 @@ Folgende Beispiele sind in diesem IG dargestellt:
 
 | Beispiel    | Beipspiel Datei |
 | -------- | ------- |
-| Dienstags und Donnerstags je 2 Tabletten | [Example-MR-Dosage-weekday-2t](./MedicationRequest-Example-MR-Dosage-weekday-2t.html)    |
+| Dienstags und Donnerstags je 2 Stück | [Example-MR-Dosage-weekday-2t](./MedicationRequest-Example-MR-Dosage-weekday-2t.html)    |
 | Unsortierte Wochentage | [Example-MR-Dosage-weekday-unsorted](./MedicationRequest-Example-MR-Dosage-weekday-unsorted.html)    |
-| Dienstags, Donnerstags und Samstags je 2 Tabletten | [Example-MR-Dosage-weekday-3t](./MedicationRequest-Example-MR-Dosage-weekday-3t.html)    |
-| Montags 2 Tabletten, Donnerstags 1 Tablette | [Example-MR-Dosage-weekday-2t-1t](./MedicationRequest-Example-MR-Dosage-weekday-2t-1t.html)     |
+| Dienstags, Donnerstags und Samstags je 2 Stück | [Example-MR-Dosage-weekday-3t](./MedicationRequest-Example-MR-Dosage-weekday-3t.html)    |
+| Montags 2 Stück, Donnerstags 1 Stück | [Example-MR-Dosage-weekday-2t-1t](./MedicationRequest-Example-MR-Dosage-weekday-2t-1t.html)     |
 | Montags 2 Tabl. für 10 Wochen  | [Example-MR-Dosage-weekday-2t-bound](./MedicationRequest-Example-MR-Dosage-weekday-2t-bound.html)    |
 
 ### Angabe und Erkennung der Dosierart
@@ -51,7 +51,7 @@ Soll das Arzneimittel in derselben Dosierung an mehreren Tagen angewandt werden,
 
 Beispiel:
 - Dosage.timing.repeat.dayOfWeek = "mon", "fri"
-- Dosage.doseAndRate.doseQuantity = 1 Tablette
-bedeutet, dass eine Tablette jeweils am Montag und Freitag einzunehmen ist.
+- Dosage.doseAndRate.doseQuantity = 1 Stück
+bedeutet, dass eine Stück jeweils am Montag und Freitag einzunehmen ist.
 
 Lesende Systeme werten entsprechend auch `Dosage.timing.repeat` aus. Wenn nur .dayOfWeek angegeben ist, ist dem Nutzer anzuzeigen, dass die Dosierung nach Wochentagen definiert ist.


### PR DESCRIPTION
This pull request updates the terminology used for dosage instructions throughout the documentation, consistently changing references from "Tablette" ("tablet") to "Stück" ("piece"). This affects examples, explanations, and schema descriptions in multiple markdown files, ensuring that the unit "Stück" is now the standard for structured dosage information.

**Terminology update:**
* All instances of "Tablette" have been replaced with "Stück" in dosage examples, schema explanations, and structured unit descriptions across the documentation, including in `dosierung-dgmp.md`, `dosierung-rahmenbedingungen.md`, `dosierung-rahmenvorgaben.md`, and `dosierung-textgenerierung.md`. [[1]](diffhunk://#diff-96eea8bb7381bc46a0f3693788d0644736c7e4b8983bbe0fe1c3a579bf888d70L23-R23) [[2]](diffhunk://#diff-96eea8bb7381bc46a0f3693788d0644736c7e4b8983bbe0fe1c3a579bf888d70L87-R90) [[3]](diffhunk://#diff-96eea8bb7381bc46a0f3693788d0644736c7e4b8983bbe0fe1c3a579bf888d70L107-R108) [[4]](diffhunk://#diff-4d697a2be7159b257944b0e2125bf4b178cefbf73863f3c99451357c615bb0f8L24-R40) [[5]](diffhunk://#diff-4d697a2be7159b257944b0e2125bf4b178cefbf73863f3c99451357c615bb0f8L53-R53) [[6]](diffhunk://#diff-7bc9ad8909c71227d0fa6e1753f5eb7f9ea5f1661787aa5cfbac9e7b351c2e06L19-R19) [[7]](diffhunk://#diff-7bc9ad8909c71227d0fa6e1753f5eb7f9ea5f1661787aa5cfbac9e7b351c2e06L30-R50) [[8]](diffhunk://#diff-0af679fc9c0455ee310151d6593cd24fd4a8c50408a80cb608b8fbcd846b2344L100-R100)

**Example updates:**
* Dosage examples in schema files for freitext, interval, weekday, time of day, and combination schemas have been updated to use "Stück" instead of "Tablette". [[1]](diffhunk://#diff-42a5ae3804aa754d72b4ec3400340fbe93fa283d0e0fe4b411991a635ae70995L11-R11) [[2]](diffhunk://#diff-f518945784340cbb08dd974acd9b4499ba73eca40f84975b10c0741d79fd6f35L13-R15) [[3]](diffhunk://#diff-e75d7b01501f45a37b08a9bfe521eea679437a0b6e266e182c5ce4a135806ed0L15-R19) [[4]](diffhunk://#diff-aaebd0a75e6f1cb207a9efb871ad0972c976358d3014d1a3f27ca3aa698ba34fL16-R20) [[5]](diffhunk://#diff-aaebd0a75e6f1cb207a9efb871ad0972c976358d3014d1a3f27ca3aa698ba34fL51-R52) [[6]](diffhunk://#diff-337f64faed096d4e574df31191c041a6dc80e284ca293bd8b87e426788103afcL20-R20) [[7]](diffhunk://#diff-e9b5705989d7b7d6dc55d7f24eebab5f230bd190a00d4df8278bc161d228dc0bL20-R23)

**Schema explanations:**
* Explanations describing how to structure dosage units, timing, and multiple dosages now reference "Stück" to match the updated terminology. [[1]](diffhunk://#diff-c458d835f442ca38ab9a1d27ced34c12868fd72ff3eaf106c7231c68156b628bL54-R55) [[2]](diffhunk://#diff-e9b5705989d7b7d6dc55d7f24eebab5f230bd190a00d4df8278bc161d228dc0bL54-R55)

These changes ensure consistency and clarity in the documentation regarding dosage units, aligning all examples and explanations with the chosen terminology "Stück".