### PR TITLE
fix: clarify mustSupport requirements for implementation and processing of elements

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -12,13 +12,11 @@ Dieser Implementation Guide wird kontinuierlich weiterentwickelt und verbessert.
 
 ### Must Support
 
-In diesem Implementation Guide – insbesondere in den anwendungsfallspezifischen Profilen – werden [Must Support Flags](https://www.hl7.org/fhir/profiling.html#mustsupport) verwendet. Implementierende Systeme sollen sicherstellen, dass Elemente mit diesem Flag sowohl lesend als auch schreibend unterstützt werden.
+Elemente mit der Eigenschaft [mustSupport](https://www.hl7.org/fhir/profiling.html#mustsupport) müssen immer implementiert werden. Hierbei handelt es sich um Elemente, die unabhängig von der Kardinalität (Ausnahme: 0…0) unterstützt werden müssen, sofern die entsprechenden Informationen vorliegen.
 
-**Für schreibende Systeme gilt:**  
-Nutzende sollen dabei unterstützt werden, alle verfügbaren Informationen in Must-Support-Elemente einzutragen. Ist eine Information nicht vorhanden, kann das entsprechende Feld ausgelassen werden.
+Die Software, welche die Dateien erstellt, muss die mit „mustSupport“ gekennzeichneten Elemente (mustSupport value="true") unterstützen – befüllen und übermitteln können.
 
-**Für lesende Systeme gilt:**  
-Sind Must-Support-Elemente in einer Instanz vorhanden, dürfen sie nicht zu Fehlern in der Anwendung führen. Die enthaltenen Informationen sollen dem Nutzenden angezeigt werden.
+Die Software, welche die Dateien verarbeitet, muss die mit „mustSupport“ gekennzeichneten Elemente (mustSupport value="true") unterstützen – auslesen und verarbeiten können.
 
 ### Zielgruppen
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the requirements for handling `mustSupport` elements in FHIR profiles. The changes provide more precise guidance for both systems that create and process files, emphasizing mandatory support for these elements regardless of cardinality (except for 0…0).

Documentation improvements:

* Updated the explanation of `mustSupport` in `input/pagecontent/index.md` to specify that elements with the `mustSupport` property must always be implemented, and clarified the responsibilities for both creating and processing software regarding these elements.