### PR TITLE
Only one dosage

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -80,7 +80,6 @@ and
 ((dayOfWeek.empty() and (when.exists() or timeOfDay.exists())) implies periodUnit = 'd')"
 Severity: #error
 
-/* Enforce a single dosageInstruction when only timeOfDay is used (no dayOfWeek/when) and period/periodUnit and dose are equal */
 Invariant: TimingSingleDosageForTimeOfDay
 Description: "Wenn nur timeOfDay verwendet wird und täglich dosiert wird, ist die Angabe in einem einzigen Dosage-Element zu modellieren. Mehrere Dosage-Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet."
 Expression: "(
@@ -121,7 +120,6 @@ Expression: "(
 "
 Severity: #error
 
-/* Enforce a single dosageInstruction when only when is used (no dayOfWeek/timeOfDay) and period/periodUnit and dose are equal */
 Invariant: TimingSingleDosageForWhen
 Description: "Wenn nur when verwendet wird und täglich dosiert wird, ist die Angabe in einem einzigen Dosage-Element zu modellieren. Mehrere Dosage-Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet."
 Expression: "(

--- a/input/fsh/examples/constraint_examples_prefer_single_timeOfDay.fsh
+++ b/input/fsh/examples/constraint_examples_prefer_single_timeOfDay.fsh
@@ -1,0 +1,23 @@
+Instance: Invalid-Dosage-C-TimingSingleDosageForTimeOfDay-01-of-01
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: split timeOfDay into two dosages (same period/dose)"
+Description: "Zwei Dosagen mit identischem Intervall und Dosis, jeweils eine Uhrzeit – sollte zu einer Dosage zusammengeführt werden."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * timeOfDay[+] = "08:00:00"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * timing.repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * timeOfDay[+] = "20:00:00"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"

--- a/input/fsh/examples/constraint_examples_prefer_single_when.fsh
+++ b/input/fsh/examples/constraint_examples_prefer_single_when.fsh
@@ -1,0 +1,23 @@
+Instance: Invalid-Dosage-C-TimingSingleDosageForWhen-01-of-02
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: split when into two dosages (same period/dose)"
+Description: "Zwei Dosagen mit identischem Intervall und Dosis, jeweils ein Zeitraum (MORN/EVE) – sollte zu einer Dosage zusammengeführt werden."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * when[+] = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * timing.repeat
+    * frequency = 1
+    * period = 1
+    * periodUnit = #d
+    * when[+] = #EVE
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"

--- a/input/includes/dosage-constraint-TimingSingleDosageForTimeOfDay-examples.md
+++ b/input/includes/dosage-constraint-TimingSingleDosageForTimeOfDay-examples.md
@@ -1,0 +1,4 @@
+| File | generated dosage instruction text | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationRequest-Invalid-Dosage-C-TimingSingleDosageForTimeOfDay-01-of-01](./MedicationRequest-Invalid-Dosage-C-TimingSingleDosageForTimeOfDay-01-of-01.html) | täglich: um 08:00 Uhr — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  | 08:00:00 |  |  |
+|  | täglich: um 20:00 Uhr — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  | 20:00:00 |  |  |

--- a/input/includes/dosage-constraint-TimingSingleDosageForWhen-examples.md
+++ b/input/includes/dosage-constraint-TimingSingleDosageForWhen-examples.md
@@ -1,0 +1,4 @@
+| File | generated dosage instruction text | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationRequest-Invalid-Dosage-C-TimingSingleDosageForWhen-01-of-02](./MedicationRequest-Invalid-Dosage-C-TimingSingleDosageForWhen-01-of-02.html) | täglich: morgens — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  |  | MORN |  |
+|  | täglich: abends — je 1 Stück | 1 Stück |  |  | 1 | 1 | d |  |  | EVE |  |

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -131,3 +131,39 @@ Damit wird verhindert, dass für ein Intervall mehrere widersprüchliche Zeitpun
 Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneTimeForInterval-examples.md%}
+
+### TimingBoundsUnitMatchesCode
+
+**Beschreibung:**  
+Die Einheit (`boundsDuration.unit`) muss zum UCUM‑Code (`boundsDuration.code`) passen; z. B. `wk` nur mit „Woche(n)“, `d` nur mit „Tag(e)“, `mo` nur mit „Monat(e)“, `a` nur mit „Jahr(e)“.
+
+**Warum?**  
+Verhindert widersprüchliche Angaben wie `code='wk'` mit `unit='Tag(e)'`.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingBoundsUnitMatchesCode-examples.md%}
+
+### TimingSingleDosageForTimeOfDay
+
+**Beschreibung:**  
+Wenn nur `timeOfDay` verwendet wird und täglich dosiert wird, sind mehrere Tageszeiten in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
+
+**Warum?**  
+Verhindert unnötige Aufsplitterung gleichartiger Dosierungen und sorgt für eine klare, eindeutige Modellierung der Tageszeiten.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingSingleDosageForTimeOfDay-examples.md%}
+
+### TimingSingleDosageForWhen
+
+**Beschreibung:**  
+Wenn nur `when` verwendet wird und täglich dosiert wird, sind mehrere Zeitabschnitte des Tages in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
+
+**Warum?**  
+Verhindert unnötige Aufsplitterung gleichartiger Dosierungen und sorgt für eine klare, eindeutige Modellierung der Tagesabschnitte.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingSingleDosageForWhen-examples.md%}


### PR DESCRIPTION
This pull request introduces two new constraints to the `TimingDgMP` datatype to ensure clearer and more consistent modeling of medication dosages, specifically when only `timeOfDay` or `when` is used for daily dosing. It also adds documentation and example instances to illustrate invalid cases that violate these constraints.

**New constraints for dosage modeling:**

* Added the `TimingSingleDosageForTimeOfDay` invariant to enforce that, when only `timeOfDay` is used with daily dosing and the dose is the same, all times must be combined into a single `Dosage` element unless the doses differ.
* Added the `TimingSingleDosageForWhen` invariant to enforce that, when only `when` is used with daily dosing and the dose is the same, all times must be combined into a single `Dosage` element unless the doses differ.
* Registered both invariants in the `TimingDgMP` datatype definition to ensure they are enforced.

**Documentation and examples:**

* Updated `dosierung-constraints.md` to explain the new constraints and their rationale, and included example tables for invalid cases.
* Added example instances in `constraint_examples_prefer_single_timeOfDay.fsh` and `constraint_examples_prefer_single_when.fsh` that demonstrate invalid cases where the same dose and interval are split across multiple `Dosage` elements. [[1]](diffhunk://#diff-e5afece8b3ea1bd024f99770b28b64a43e2b0a3d7353174d5cf209003660cccfR1-R23) [[2]](diffhunk://#diff-b26bd4d5a1d72d3cbe487e278562eac3f64f64491c8df8133d99c2701992cb3dR1-R23)
* Added corresponding markdown tables summarizing these invalid examples for both constraints. [[1]](diffhunk://#diff-ad24eb83e7a39cfa2d17ef615ed4e311249391927b0df5d92b39ee9ff0fb84a9R1-R4) [[2]](diffhunk://#diff-5c68ab3cb3629075bec4ce83117a59df28408c09d7f77c8a4a292215692c8b83R1-R4)