### PR TITLE
feat: add FreeTextSingleDosageOnly invariant to enforce single dosage element in free text

### DIFF
--- a/input/fsh/datatypes/DosageDE.fsh
+++ b/input/fsh/datatypes/DosageDE.fsh
@@ -9,6 +9,7 @@ Description: "Gibt an, wie das Medikament eingenommen oder verabreicht wurde bzw
 * obeys DosageStructuredRequiresBoth
 * obeys DosageDoseUnitSameCode
 * obeys DosageWarnungViererschemaInText
+* obeys FreeTextSingleDosageOnlyWarning
 * text 0..1 MS
   * ^short = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Stück bei Bedarf'"
   * ^definition = "Freitext-Dosierungsanweisungen, z. B. 'Maximal 3x täglich 1 Stück bei Bedarf'. Als Quelle dient hier ausschließlich der Arzt oder Apotheker"
@@ -36,6 +37,23 @@ Expression: "(%resource.ofType(MedicationRequest).dosageInstruction |
   (text.empty() and (timing.exists() or doseAndRate.exists()))
 )
 "
+Severity: #warning
+
+Invariant: FreeTextSingleDosageOnlyWarning
+Description: "Wenn eine Dosierung als reiner Freitext angegeben ist, soll nur genau ein Dosage-Element existieren."
+Expression: "(
+  (%resource.ofType(MedicationRequest).dosageInstruction |
+   %resource.ofType(MedicationDispense).dosageInstruction |
+   %resource.ofType(MedicationStatement).dosage
+  ).exists(text.exists() and timing.empty() and doseAndRate.empty())
+)
+implies
+(
+  (%resource.ofType(MedicationRequest).dosageInstruction |
+   %resource.ofType(MedicationDispense).dosageInstruction |
+   %resource.ofType(MedicationStatement).dosage
+  ).count() = 1
+)"
 Severity: #warning
 
 Invariant: DosageStructuredRequiresBoth

--- a/input/fsh/datatypes/DosageDgMP.fsh
+++ b/input/fsh/datatypes/DosageDgMP.fsh
@@ -5,6 +5,7 @@ Title: "Dosage dgMP"
 Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenommen wird/wurde oder eingenommen werden soll."
 * obeys DosageStructuredOrFreeText
 * obeys DosageStructuredRequiresGeneratedText
+* obeys FreeTextSingleDosageOnly
 * timing only TimingDgMP
 * doseAndRate 0..1 // Nur eine Dosierung für eine Medikation erlauben
   * ^comment = "Begründung Einschränkung Kardinalität: Nur eine Dosierung pro Medikation ist in der ersten Ausbaustufe des dgMP vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
@@ -77,4 +78,21 @@ implies
 )
 )
 "
+Severity: #error
+
+Invariant: FreeTextSingleDosageOnly
+Description: "Wenn eine Dosierung als reiner Freitext angegeben ist, darf nur genau ein Dosage-Element existieren."
+Expression: "(
+  (%resource.ofType(MedicationRequest).dosageInstruction |
+   %resource.ofType(MedicationDispense).dosageInstruction |
+   %resource.ofType(MedicationStatement).dosage
+  ).exists(text.exists() and timing.empty() and doseAndRate.empty())
+)
+implies
+(
+  (%resource.ofType(MedicationRequest).dosageInstruction |
+   %resource.ofType(MedicationDispense).dosageInstruction |
+   %resource.ofType(MedicationStatement).dosage
+  ).count() = 1
+)"
 Severity: #error

--- a/input/fsh/examples/constraint_examples_invalid_freetext_single_only.fsh
+++ b/input/fsh/examples/constraint_examples_invalid_freetext_single_only.fsh
@@ -1,0 +1,15 @@
+// Invalid example for FreeTextSingleDosageOnly: multiple Dosage entries with pure free text
+Instance: Invalid-Dosage-C-FreeTextSingleDosageOnly-01-of-01
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid Dosage - FreeText must be single"
+Description: "Invalid: Freitextdosierung vorhanden, aber mehr als ein Dosage-Element vorhanden."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Test Medication"
+* dosageInstruction[+]
+  * text = "Morgens je 1 Tablette"
+* dosageInstruction[+]
+  * text = "Abends je 1 Tablette"
+

--- a/input/includes/dosage-constraint-FreeTextSingleDosageOnly-examples.md
+++ b/input/includes/dosage-constraint-FreeTextSingleDosageOnly-examples.md
@@ -1,0 +1,4 @@
+| File | generated dosage instruction text | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationRequest-Invalid-Dosage-C-FreeTextSingleDosageOnly-01-of-01](./MedicationRequest-Invalid-Dosage-C-FreeTextSingleDosageOnly-01-of-01.html) |  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |  |

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -2,9 +2,9 @@ Im Folgenden werden alle definierten Invarianten für das Timing-Profil aufgelis
 
 Neben den Timing-bezogenen Regeln existieren weitere Invarianten auf Ebene des Dosage-Elements (Profil `DosageDE` bzw. `DosageDgMP`). Diese steuern, wie strukturierte und Freitext‑Dosierungen zulässig kombiniert werden und stellen Konsistenz bei Dosiereinheiten sicher. Alle aktuell definierten Constraints sind nachfolgend aufgeführt.
 
-## Timing-bezogene Constraints
+### Timing-bezogene Constraints
 
-### TimingFrequencyCount
+#### TimingFrequencyCount
 
 **Beschreibung:**  
 Die Häufigkeit (`frequency`) muss mit der Anzahl der angegebenen Zeitpunkte (`timeOfDay` oder `when`) übereinstimmen, abhängig davon, welche Felder gesetzt sind.
@@ -16,7 +16,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingFrequencyCount-examples.md%}
 
-### TimingPeriodUnit
+#### TimingPeriodUnit
 
 **Beschreibung:**  
 Wenn Wochentage (`dayOfWeek`) angegeben sind, muss die Zeiteinheit (`periodUnit`) "Woche" (`wk`) sein, andernfalls "Tag" (`d`).
@@ -28,7 +28,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingPeriodUnit-examples.md%}
 
-### TimingOnlyOneType
+#### TimingOnlyOneType
 
 **Beschreibung:**  
 Es darf pro Dosierung nur eine Art der Zeitangabe verwendet werden (z.B. ausschließlich `4-Schema`, `TimeOfDay`, `DayOfWeek`, `Interval`, Kombinationen wie `DayOfWeek+TimeOfDay` oder `Interval+TimeOfDay`).
@@ -40,7 +40,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneType-examples.md%}
 
-### TimingOnlyOneWhen
+#### TimingOnlyOneWhen
 
 **Beschreibung:**  
 Es darf nicht derselbe Zeitraum des Tages (`when`) in mehreren Dosierungsinstanzen vorkommen.
@@ -52,7 +52,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneWhen-examples.md%}
 
-### TimingOnlyWhenOrTimeOfDay
+#### TimingOnlyWhenOrTimeOfDay
 
 **Beschreibung:**  
 Es darf nicht die Tageszeit `timeOfDay` und der Zeitraum des Tages `when` in mehreren Dosierungsinstanzen gleichzeitig vorkommen.
@@ -64,7 +64,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md%}
 
-### TimingOnlyOneTimeOfDay
+#### TimingOnlyOneTimeOfDay
 
 **Beschreibung:**  
 Es darf nicht dieselbe Tageszeit (`timeOfDay`) in mehreren Dosierungsinstanzen vorkommen.
@@ -76,7 +76,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneTimeOfDay-examples.md%}
 
-### TimingOnlyOneDayOfWeek
+#### TimingOnlyOneDayOfWeek
 
 **Beschreibung:**  
 Es darf nicht derselbe Wochentag (`dayOfWeek`) in mehreren Dosierungsinstanzen vorkommen.
@@ -88,7 +88,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneDayOfWeek-examples.md%}
 
-### TimingOnlyOneBounds
+#### TimingOnlyOneBounds
 
 **Beschreibung:**  
 Für die Dauer (`bounds` vom Typ `Duration`) dürfen pro Ressource nur ein Wert und ein Code vorkommen.
@@ -100,7 +100,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneBounds-examples.md%}
 
-### TimingIntervalOnlyOneFrequency
+#### TimingIntervalOnlyOneFrequency
 
 **Beschreibung:**  
 Bei Intervallangaben darf es nur eine Dosierungsinstanz geben.
@@ -112,7 +112,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingIntervalOnlyOneFrequency-examples.md%}
 
-### TimingOnlyOnePeriodForDayOfWeek
+#### TimingOnlyOnePeriodForDayOfWeek
 
 **Beschreibung:**  
 Wenn für einen Wochentag mehrere Einträge existieren, müssen sich deren Zeitangaben (`when`/`timeOfDay`) unterscheiden.
@@ -124,7 +124,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOnePeriodForDayOfWeek-examples.md%}
 
-### TimingOnlyOneTimeForInterval
+#### TimingOnlyOneTimeForInterval
 
 **Beschreibung:**  
 Bei Intervallangaben mit Zeitpunkten (`when` oder `timeOfDay`) dürfen die Zeitangaben nicht mehrfach vorkommen und die Periodenangaben müssen eindeutig sein.
@@ -136,7 +136,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingOnlyOneTimeForInterval-examples.md%}
 
-### TimingBoundsUnitMatchesCode
+#### TimingBoundsUnitMatchesCode
 
 **Beschreibung:**  
 Die Einheit (`boundsDuration.unit`) muss zum UCUM‑Code (`boundsDuration.code`) passen; z. B. `wk` nur mit „Woche(n)“, `d` nur mit „Tag(e)“, `mo` nur mit „Monat(e)“, `a` nur mit „Jahr(e)“.
@@ -148,7 +148,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingBoundsUnitMatchesCode-examples.md%}
 
-### TimingSingleDosageForTimeOfDay
+#### TimingSingleDosageForTimeOfDay
 
 **Beschreibung:**  
 Wenn nur `timeOfDay` verwendet wird und täglich dosiert wird, sind mehrere Tageszeiten in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
@@ -160,7 +160,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingSingleDosageForTimeOfDay-examples.md%}
 
-### TimingSingleDosageForWhen
+#### TimingSingleDosageForWhen
 
 **Beschreibung:**  
 Wenn nur `when` verwendet wird und täglich dosiert wird, sind mehrere Zeitabschnitte des Tages in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
@@ -172,11 +172,11 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-TimingSingleDosageForWhen-examples.md%}
 
-## Dosage-bezogene Constraints
+### Dosage-bezogene Constraints
 
 Die folgenden Invarianten beziehen sich auf das Dosage-Element insgesamt (nicht nur auf `timing.repeat`). Sie wirken über alle Dosierungsinstanzen einer Ressource (z. B. alle `dosageInstruction` eines `MedicationRequest`).
 
-### DosageStructuredOrFreeText / DosageStructuredOrFreeTextWarning
+#### DosageStructuredOrFreeText / DosageStructuredOrFreeTextWarning
 
 **Beschreibung:**  
 Eine Dosierungsangabe darf entweder vollständig strukturiert (mit `timing` und/oder `doseAndRate`) oder ausschließlich als Freitext (`text`) vorliegen - eine Mischung ist nicht zulässig.
@@ -195,7 +195,7 @@ Gültige Varianten (Warnungskontext – nur Text oder nur Struktur):
 
 {% include dosage-constraint-DosageStructuredOrFreeTextWarning-examples.md%}
 
-### DosageStructuredRequiresBoth
+#### DosageStructuredRequiresBoth
 
 **Beschreibung:**  
 Wenn eine strukturierte Dosierung angegeben wird, müssen sowohl zeitliche Angaben (`timing`) als auch die Dosis (`doseAndRate`) vorhanden sein.
@@ -207,7 +207,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-DosageStructuredRequiresBoth-examples.md%}
 
-### DosageStructuredRequiresGeneratedText
+#### DosageStructuredRequiresGeneratedText
 
 **Beschreibung:**  
 Liegt eine strukturierte Dosierung vor (strukturierte Elemente befüllt, Freitext leer), muss die Extension `GeneratedDosageInstructionsMeta` existieren sowie genau eine der FHIR R5 RenderedDosageInstruction-Extensions passend zur Ressource (MedicationRequest/Dispense/Statement).
@@ -219,7 +219,19 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-DosageStructuredRequiresGeneratedText-examples.md%}
 
-### DosageDoseUnitSameCode
+#### FreeTextSingleDosageOnly
+
+**Beschreibung:**  
+Wenn eine Dosierung als reiner Freitext angegeben ist (nur `text`, kein `timing`/`doseAndRate`), darf in der Ressource insgesamt nur genau ein `Dosage`‑Eintrag vorkommen.
+
+**Warum?**  
+Verhindert widersprüchliche oder doppelte Freitextangaben, die nicht automatisch zusammengeführt werden können. Fördert eindeutige, konsolidierte Freitext‑Anweisungen, wenn keine strukturierte Modellierung erfolgt.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-FreeTextSingleDosageOnly-examples.md%}
+
+#### DosageDoseUnitSameCode
 
 **Beschreibung:**  
 Alle Dosierungsinstanzen innerhalb derselben Ressource müssen dieselbe Dosiereinheit (Code) verwenden.
@@ -231,7 +243,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-DosageDoseUnitSameCode-examples.md%}
 
-### DosageWarnungViererschemaInText
+#### DosageWarnungViererschemaInText
 
 **Beschreibung:**  
 Warnung, wenn ein klassisches 4-Schema (z. B. Darstellung wie "1-0-1-0") im Freitext angegeben wird, obwohl eine strukturierte Abbildung möglich wäre.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -53,7 +53,7 @@ pages:
   dosierung-text-hinzufuegen.md:
     title: Bereitstellung des Dosierungstextes
   dosierung-constraints.md:
-    title: Übersicht der Timing-Invarianten
+    title: Übersicht der Timing & Dosierungs-Invarianten
   schema-freitext.md:
     title: Freitext-Dosierung
   schema-tageszeit.md:
@@ -107,7 +107,7 @@ menu:
     dgMP Rahmenvorgaben: dosierung-dgmp.html
     Dosis Textgenerierung: dosierung-textgenerierung.html
     Bereitstellung des Dosierungstextes: dosierung-text-hinzufuegen.html
-    Übersicht der Timing-Invarianten: dosierung-constraints.html
+    Übersicht der Timing & Dosierungs-Invarianten: dosierung-constraints.html
   Dosierschemata:
     Freitext-Dosierung: schema-freitext.html
     Schema mit Tageszeiten-Bezug: schema-tageszeit.html


### PR DESCRIPTION
This pull request introduces a new constraint to ensure that when a medication dosage is specified as pure free text (i.e., only the `text` field is set, with no structured timing or dose information), only one dosage entry is allowed per resource. The change affects both the `DosageDE` and `DosageDgMP` profiles, updates documentation to include and explain the new constraint, and adds an example illustrating invalid usage. Additionally, the documentation structure is improved for clarity.

**New Free Text Dosage Constraint**

* Added the `FreeTextSingleDosageOnly` invariant to both `DosageDE` and `DosageDgMP` profiles, enforcing that only one dosage entry is allowed when using pure free text. Severity is set to `#warning` for `DosageDE` and `#error` for `DosageDgMP`. [[1]](diffhunk://#diff-321bf8893e636615669c7ee2cf23e7712ec2b111905cab2fadb48aae674758f4R12) [[2]](diffhunk://#diff-321bf8893e636615669c7ee2cf23e7712ec2b111905cab2fadb48aae674758f4R42-R58) [[3]](diffhunk://#diff-219bf3f0dff6d4c6ab325fb0fe503bbb7a74bcc569e2b3b7f05e32793eb0b165R8) [[4]](diffhunk://#diff-219bf3f0dff6d4c6ab325fb0fe503bbb7a74bcc569e2b3b7f05e32793eb0b165R82-R98)

**Documentation Updates**

* Expanded the constraints documentation in `dosierung-constraints.md` to describe and justify the new `FreeTextSingleDosageOnly` rule, including rationale and invalid examples. Also, restructured headings for improved readability and distinction between timing and dosage constraints. [[1]](diffhunk://#diff-4bbdcc34f30d260fdc5d2ad38413261344db86bd9dc77c746a54b381bcd7e144L5-R7) [[2]](diffhunk://#diff-4bbdcc34f30d260fdc5d2ad38413261344db86bd9dc77c746a54b381bcd7e144L175-R179) [[3]](diffhunk://#diff-4bbdcc34f30d260fdc5d2ad38413261344db86bd9dc77c746a54b381bcd7e144L222-R234) [[4]](diffhunk://#diff-4bbdcc34f30d260fdc5d2ad38413261344db86bd9dc77c746a54b381bcd7e144L234-R246)

**Examples**

* Added an invalid example instance file (`constraint_examples_invalid_freetext_single_only.fsh`) showing multiple free text dosage entries, and referenced it in the documentation for clarity. [[1]](diffhunk://#diff-6445b6ab0f177f3d52d9a216d661b84821de937a7fca855fa580bfe1cd4acd92R1-R15) [[2]](diffhunk://#diff-6030fc2c786c34e99fc62f49db3c18af5bd341ad35a088fa824e12f1e035a190R1-R4)

**Config and Navigation**

* Updated page and menu titles in `sushi-config.yaml` to reflect the expanded scope of the constraints documentation, now covering both timing and dosage invariants. [[1]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L56-R56) [[2]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L110-R110)