### PR TITLE
feat: moved GeneratedDosageInstructionsMeta on backportExtension.value

### DIFF
--- a/input/fsh/profiles/MedicationCommonRuleset.fsh
+++ b/input/fsh/profiles/MedicationCommonRuleset.fsh
@@ -7,7 +7,7 @@ RuleSet: MedicationCommonRuleset
   * valueMarkdown
     * ^short = "Hinweis: In der ersten Ausbaustufe des dgMP ist nur einfacher Text (String) zulässig; Markdown wird nicht unterstützt."
     * ^definition = "Abweichend von FHIR R5 (Typ Markdown) darf in der ersten Ausbaustufe des dgMP ausschließlich Klartext ohne Markdown‑Formatierungen (z. B. Überschriften, Listen, Links) geliefert werden."
-
-* extension[generatedDosageInstructionsMeta]
-  * ^short = "Metadaten zu den generierten Dosierungsanweisungen"
-  * ^definition = "Diese Extension enthält zusätzliche Metadaten zu den automatisch generierten Dosierungsanweisungen, wie z.B. Informationen zur Generierung oder zum Ursprung der Daten."
+    * extension contains GeneratedDosageInstructionsMetaEx named generatedDosageInstructionsMeta 0..1 MS
+    * extension[generatedDosageInstructionsMeta]
+      * ^short = "Metadaten zu den generierten Dosierungsanweisungen"
+      * ^definition = "Diese Extension enthält zusätzliche Metadaten zu den automatisch generierten Dosierungsanweisungen, wie z.B. Informationen zur Generierung oder zum Ursprung der Daten."

--- a/input/fsh/profiles/MedicationCommonRuleset.fsh
+++ b/input/fsh/profiles/MedicationCommonRuleset.fsh
@@ -10,4 +10,4 @@ RuleSet: MedicationCommonRuleset
     * extension contains GeneratedDosageInstructionsMetaEx named generatedDosageInstructionsMeta 0..1 MS
     * extension[generatedDosageInstructionsMeta]
       * ^short = "Metadaten zu den generierten Dosierungsanweisungen"
-      * ^definition = "Diese Extension enthält zusätzliche Metadaten zu den automatisch generierten Dosierungsanweisungen, wie z.B. Informationen zur Generierung oder zum Ursprung der Daten."
+      * ^definition = "Diese Extension enthält zusätzliche Metadaten zu den automatisch generierten Dosierungsanweisungen."

--- a/input/fsh/profiles/MedicationDispenseDgMP.fsh
+++ b/input/fsh/profiles/MedicationDispenseDgMP.fsh
@@ -5,7 +5,6 @@ Title: "Medication Dispense dgMP"
 Description: "Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht. Stattdessen sollte das jeweils passende Dosage-Profil direkt in das eigene Profil eingebunden werden."
 
 * extension contains $medicationDispense-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
-  and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
 
 * dosageInstruction only DosageDgMP

--- a/input/fsh/profiles/MedicationRequestDgMP.fsh
+++ b/input/fsh/profiles/MedicationRequestDgMP.fsh
@@ -5,7 +5,6 @@ Title: "Medication Request dgMP"
 Description: "Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht. Stattdessen sollte das jeweils passende Dosage-Profil direkt in das eigene Profil eingebunden werden."
 
 * extension contains $medicationRequest-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
-  and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
 
 * dosageInstruction only DosageDgMP

--- a/input/fsh/profiles/MedicationStatementDgMP.fsh
+++ b/input/fsh/profiles/MedicationStatementDgMP.fsh
@@ -5,7 +5,6 @@ Title: "Medication Statement dgMP"
 Description: "Dieses Profil dient ausschließlich der Validierung des Implementation Guides und ist nicht für den produktiven Einsatz gedacht. Stattdessen sollte das jeweils passende Dosage-Profil direkt in das eigene Profil eingebunden werden."
 
 * extension contains $medicationStatement-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
-  and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
 
 * dosage only DosageDgMP


### PR DESCRIPTION
Achtung: Examples und Scripte noch nicht angepasst!!

This pull request refactors how the `GeneratedDosageInstructionsMeta` extension is included in medication-related FHIR profiles. Instead of declaring the extension directly in each profile, it is now added centrally within the `MedicationCommonRuleset` to promote consistency and reduce duplication.

Refactoring of extension inclusion:

* The `GeneratedDosageInstructionsMetaEx` extension is now added to the `valueMarkdown` element within the `MedicationCommonRuleset`, with appropriate metadata descriptions. This ensures all profiles using this ruleset include the extension in a standardized way.

Profile simplification:

* Removed the direct inclusion of the `GeneratedDosageInstructionsMeta` extension from the `MedicationDispenseDgMP`, `MedicationRequestDgMP`, and `MedicationStatementDgMP` profiles, as it is now inherited via the common ruleset. [[1]](diffhunk://#diff-437095c174b36fd7a88b660e7f6dda2e7c765609cb1313271c9030079ae594d0L8) [[2]](diffhunk://#diff-8cad0a1f6d54defd4401a27fe817c86aae5aa7545497d82d7cd48f638d158d02L8) [[3]](diffhunk://#diff-73b0b70dbb3d9eb515c1db65c969293e6228371c06eef5290a15c749ccc1f4b7L8)