### PR TITLE
Add value[x] type restrictions to inner extensions in GeneratedDosageInstructionsMeta

### DIFF
--- a/input/fsh/extensions/GeneratedDosageInstructions-Ex.fsh
+++ b/input/fsh/extensions/GeneratedDosageInstructions-Ex.fsh
@@ -9,8 +9,10 @@ Context: MedicationRequest, MedicationDispense, MedicationStatement
 * extension[language]
   * ^short = "Sprache der generierten Dosierungsanweisung"
   * ^comment = "Zur Auswahl der deutschen Sprache sollte der Code 'de-DE' verwendet werden"
+  * value[x] only code
   * valueCode 1.. MS
   * valueCode from $all-languages-vs
 * extension[algorithmVersion]
   * ^short = "Version des Algorithmus zur Generierung der Dosierungsanweisung (Version der zugrundeliegenden Python Referenzimplementierung)"
+  * value[x] only string
   * valueString 1.. MS


### PR DESCRIPTION
Add explicit type restrictions for `value[x]` in the inner extensions of `GeneratedDosageInstructionsMeta`. The `extension:language` is now restricted to `code`, and `extension:algorithmVersion` is restricted to `string`. This change addresses the issue of incorrect type listings in the IG Publisher.

Fixes #120