### PR TITLE
1.0.5

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -182,7 +182,6 @@ Expression: "(
     timing.repeat.frequency.exists() and
     timing.repeat.period.exists() and
     timing.repeat.periodUnit.exists() and
-    timing.repeat.dayOfWeek.empty() and
     (timing.repeat.when.exists() or 
     timing.repeat.timeOfDay.exists())
   implies

--- a/input/fsh/examples/dev_examples_invalid_onekind.fsh
+++ b/input/fsh/examples/dev_examples_invalid_onekind.fsh
@@ -1,5 +1,5 @@
 // when + timeOfDay
-Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Request-01-of-01
+Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Request-01-of-02
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Invalid (Request): when + timeOfDay"
@@ -22,6 +22,32 @@ Description: "CAVE: This MedicationRequest is for validation purposes and does N
     * frequency = 1
     * period = 1
     * periodUnit = #d
+
+Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Request-02-of-02
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek + timeOfDay and dayOfWeek + when"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that timeOfDay and when must not be mixed when dayOfWeek is present."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
 
 // when + dayOfWeek
 Instance: INV-C-TimingOnlyOneType-Request-01-of-05
@@ -146,12 +172,87 @@ Description: "CAVE: This MedicationRequest is for validation purposes and does N
     * period = 1
     * periodUnit = #d
 
+// dayOfWeek + dayOfWeek with when
+Instance: INV-C-TimingOnlyOneType-Request-06-of-08
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek + dayOfWeek with when"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure dayOfWeek and dayOfWeek with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #wed
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
+// interval + interval with timeOfDay
+Instance: INV-C-TimingOnlyOneType-Request-07-of-08
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): interval + interval with timeOfDay"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure interval and interval with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+
+// dayOfWeek with when + interval
+Instance: INV-C-TimingOnlyOneType-Request-08-of-08
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek with when + interval"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with when and pure interval must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * when[+] = #EVE
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
 // ============================================================
 // TimingOnlyWhenOrTimeOfDay — Dispense + Statement
 // ============================================================
 
 // when + timeOfDay - Dispense
-Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-01-of-01
+Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-01-of-02
 InstanceOf: MedicationDispenseDgMP
 Usage: #example
 Title: "Invalid (Dispense): when + timeOfDay"
@@ -174,8 +275,33 @@ Description: "CAVE: This MedicationDispense is for validation purposes and does 
     * period = 1
     * periodUnit = #d
 
+Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-02-of-02
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek + timeOfDay and dayOfWeek + when"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that timeOfDay and when must not be mixed when dayOfWeek is present."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
 // when + timeOfDay - Statement
-Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Statement-01-of-01
+Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Statement-01-of-02
 InstanceOf: MedicationStatementDgMP
 Usage: #example
 Title: "Invalid (Statement): when + timeOfDay"
@@ -197,6 +323,31 @@ Description: "CAVE: This MedicationStatement is for validation purposes and does
     * frequency = 1
     * period = 1
     * periodUnit = #d
+
+Instance: INV-C-TimingOnlyWhenOrTimeOfDay-Statement-02-of-02
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek + timeOfDay and dayOfWeek + when"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that timeOfDay and when must not be mixed when dayOfWeek is present."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
 
 // ============================================================
 // TimingOnlyOneType — Dispense examples (01–05 of 05)
@@ -319,6 +470,78 @@ Description: "CAVE: This MedicationDispense is for validation purposes and does 
     * period = 1
     * periodUnit = #d
 
+// dayOfWeek + dayOfWeek with when - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-06-of-08
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek + dayOfWeek with when"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure dayOfWeek and dayOfWeek with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #wed
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
+// interval + interval with timeOfDay - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-07-of-08
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): interval + interval with timeOfDay"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure interval and interval with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+
+// dayOfWeek with when + interval - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-08-of-08
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek with when + interval"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with when and pure interval must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * when[+] = #EVE
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
 // ============================================================
 // TimingOnlyOneType — Statement examples (01–05 of 05)
 // ============================================================
@@ -438,4 +661,76 @@ Description: "CAVE: This MedicationStatement is for validation purposes and does
   * timing.repeat
     * frequency = 1
     * period = 1
+    * periodUnit = #d
+
+// dayOfWeek + dayOfWeek with when - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-06-of-08
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek + dayOfWeek with when"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that pure dayOfWeek and dayOfWeek with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #wed
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
+// interval + interval with timeOfDay - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-07-of-08
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): interval + interval with timeOfDay"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that pure interval and interval with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+
+// dayOfWeek with when + interval - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-08-of-08
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek with when + interval"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that dayOfWeek with when and pure interval must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * when[+] = #EVE
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 3
     * periodUnit = #d

--- a/input/fsh/examples/dev_examples_invalid_onekind.fsh
+++ b/input/fsh/examples/dev_examples_invalid_onekind.fsh
@@ -173,7 +173,7 @@ Description: "CAVE: This MedicationRequest is for validation purposes and does N
     * periodUnit = #d
 
 // dayOfWeek + dayOfWeek with when
-Instance: INV-C-TimingOnlyOneType-Request-06-of-08
+Instance: INV-C-TimingOnlyOneType-Request-06-of-13
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Invalid (Request): dayOfWeek + dayOfWeek with when"
@@ -199,7 +199,7 @@ Description: "CAVE: This MedicationRequest is for validation purposes and does N
     * periodUnit = #wk
 
 // interval + interval with timeOfDay
-Instance: INV-C-TimingOnlyOneType-Request-07-of-08
+Instance: INV-C-TimingOnlyOneType-Request-07-of-13
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Invalid (Request): interval + interval with timeOfDay"
@@ -223,7 +223,7 @@ Description: "CAVE: This MedicationRequest is for validation purposes and does N
     * periodUnit = #d
 
 // dayOfWeek with when + interval
-Instance: INV-C-TimingOnlyOneType-Request-08-of-08
+Instance: INV-C-TimingOnlyOneType-Request-08-of-13
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Invalid (Request): dayOfWeek with when + interval"
@@ -243,6 +243,133 @@ Description: "CAVE: This MedicationRequest is for validation purposes and does N
 * dosageInstruction[+]
   * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
   * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek + dayOfWeek with timeOfDay
+Instance: INV-C-TimingOnlyOneType-Request-09-of-13
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek + dayOfWeek with timeOfDay"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure dayOfWeek and dayOfWeek with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #wed
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
+// interval + interval with when
+Instance: INV-C-TimingOnlyOneType-Request-10-of-13
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): interval + interval with when"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure interval and interval with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+
+// dayOfWeek with timeOfDay + interval
+Instance: INV-C-TimingOnlyOneType-Request-11-of-13
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek with timeOfDay + interval"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with timeOfDay and pure interval must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek with when + interval with when
+Instance: INV-C-TimingOnlyOneType-Request-12-of-13
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek with when + interval with when"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with when and interval with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * when[+] = #EVE
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek with timeOfDay + interval with timeOfDay
+Instance: INV-C-TimingOnlyOneType-Request-13-of-13
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dayOfWeek with timeOfDay + interval with timeOfDay"
+Description: "CAVE: This MedicationRequest is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with timeOfDay and interval with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * timeOfDay[+] = "20:00:00"
     * frequency = 1
     * period = 3
     * periodUnit = #d
@@ -471,7 +598,7 @@ Description: "CAVE: This MedicationDispense is for validation purposes and does 
     * periodUnit = #d
 
 // dayOfWeek + dayOfWeek with when - Dispense
-Instance: INV-C-TimingOnlyOneType-Dispense-06-of-08
+Instance: INV-C-TimingOnlyOneType-Dispense-06-of-13
 InstanceOf: MedicationDispenseDgMP
 Usage: #example
 Title: "Invalid (Dispense): dayOfWeek + dayOfWeek with when"
@@ -496,7 +623,7 @@ Description: "CAVE: This MedicationDispense is for validation purposes and does 
     * periodUnit = #wk
 
 // interval + interval with timeOfDay - Dispense
-Instance: INV-C-TimingOnlyOneType-Dispense-07-of-08
+Instance: INV-C-TimingOnlyOneType-Dispense-07-of-13
 InstanceOf: MedicationDispenseDgMP
 Usage: #example
 Title: "Invalid (Dispense): interval + interval with timeOfDay"
@@ -519,7 +646,7 @@ Description: "CAVE: This MedicationDispense is for validation purposes and does 
     * periodUnit = #d
 
 // dayOfWeek with when + interval - Dispense
-Instance: INV-C-TimingOnlyOneType-Dispense-08-of-08
+Instance: INV-C-TimingOnlyOneType-Dispense-08-of-13
 InstanceOf: MedicationDispenseDgMP
 Usage: #example
 Title: "Invalid (Dispense): dayOfWeek with when + interval"
@@ -538,6 +665,128 @@ Description: "CAVE: This MedicationDispense is for validation purposes and does 
 * dosageInstruction[+]
   * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
   * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek + dayOfWeek with timeOfDay - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-09-of-13
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek + dayOfWeek with timeOfDay"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure dayOfWeek and dayOfWeek with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #wed
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
+// interval + interval with when - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-10-of-13
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): interval + interval with when"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that pure interval and interval with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+
+// dayOfWeek with timeOfDay + interval - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-11-of-13
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek with timeOfDay + interval"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with timeOfDay and pure interval must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek with when + interval with when - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-12-of-13
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek with when + interval with when"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with when and interval with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * when[+] = #EVE
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek with timeOfDay + interval with timeOfDay - Dispense
+Instance: INV-C-TimingOnlyOneType-Dispense-13-of-13
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dayOfWeek with timeOfDay + interval with timeOfDay"
+Description: "CAVE: This MedicationDispense is for validation purposes and does NOT represent a valid dosageInstruction. It checks that dayOfWeek with timeOfDay and interval with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #completed
+* medicationCodeableConcept.text = "DEV Medication"
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosageInstruction[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * timeOfDay[+] = "20:00:00"
     * frequency = 1
     * period = 3
     * periodUnit = #d
@@ -664,7 +913,7 @@ Description: "CAVE: This MedicationStatement is for validation purposes and does
     * periodUnit = #d
 
 // dayOfWeek + dayOfWeek with when - Statement
-Instance: INV-C-TimingOnlyOneType-Statement-06-of-08
+Instance: INV-C-TimingOnlyOneType-Statement-06-of-13
 InstanceOf: MedicationStatementDgMP
 Usage: #example
 Title: "Invalid (Statement): dayOfWeek + dayOfWeek with when"
@@ -689,7 +938,7 @@ Description: "CAVE: This MedicationStatement is for validation purposes and does
     * periodUnit = #wk
 
 // interval + interval with timeOfDay - Statement
-Instance: INV-C-TimingOnlyOneType-Statement-07-of-08
+Instance: INV-C-TimingOnlyOneType-Statement-07-of-13
 InstanceOf: MedicationStatementDgMP
 Usage: #example
 Title: "Invalid (Statement): interval + interval with timeOfDay"
@@ -712,7 +961,7 @@ Description: "CAVE: This MedicationStatement is for validation purposes and does
     * periodUnit = #d
 
 // dayOfWeek with when + interval - Statement
-Instance: INV-C-TimingOnlyOneType-Statement-08-of-08
+Instance: INV-C-TimingOnlyOneType-Statement-08-of-13
 InstanceOf: MedicationStatementDgMP
 Usage: #example
 Title: "Invalid (Statement): dayOfWeek with when + interval"
@@ -731,6 +980,128 @@ Description: "CAVE: This MedicationStatement is for validation purposes and does
 * dosage[+]
   * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
   * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek + dayOfWeek with timeOfDay - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-09-of-13
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek + dayOfWeek with timeOfDay"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that pure dayOfWeek and dayOfWeek with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #mon
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #wed
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+
+// interval + interval with when - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-10-of-13
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): interval + interval with when"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that pure interval and interval with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 2
+    * periodUnit = #d
+
+// dayOfWeek with timeOfDay + interval - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-11-of-13
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek with timeOfDay + interval"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that dayOfWeek with timeOfDay and pure interval must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek with when + interval with when - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-12-of-13
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek with when + interval with when"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that dayOfWeek with when and interval with when must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * when[+] = #EVE
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * when[+] = #MORN
+    * frequency = 1
+    * period = 3
+    * periodUnit = #d
+
+// dayOfWeek with timeOfDay + interval with timeOfDay - Statement
+Instance: INV-C-TimingOnlyOneType-Statement-13-of-13
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dayOfWeek with timeOfDay + interval with timeOfDay"
+Description: "CAVE: This MedicationStatement is for validation purposes and does NOT represent a valid dosage. It checks that dayOfWeek with timeOfDay and interval with timeOfDay must not be mixed."
+* subject.display = "DEV Dosage"
+* status = #active
+* medicationCodeableConcept.text = "DEV Medication"
+* dosage[+]
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * dayOfWeek[+] = #fri
+    * timeOfDay[+] = "08:00:00"
+    * frequency = 1
+    * period = 1
+    * periodUnit = #wk
+* dosage[+]
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * timing.repeat
+    * timeOfDay[+] = "20:00:00"
     * frequency = 1
     * period = 3
     * periodUnit = #d

--- a/input/includes/dosage-constraint-TimingOnlyOneType-examples.md
+++ b/input/includes/dosage-constraint-TimingOnlyOneType-examples.md
@@ -5,13 +5,22 @@
 | [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-03-of-05](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-03-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | fri | 07:00:00 |  |  |
 | [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-04-of-05](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-04-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 12:00:00 |  |  |
 | [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-05-of-05](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-05-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | wk<br>d | tue |  |  |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-06-of-08](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-06-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-07-of-08](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-07-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-08-of-08](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-08-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-01-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-01-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | mon |  | EVE |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-02-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-02-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  |  | NOON |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-03-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-03-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | fri | 07:00:00 |  |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-04-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-04-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 12:00:00 |  |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-05-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-05-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | wk<br>d | tue |  |  |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-06-of-08](./MedicationRequest-INV-C-TimingOnlyOneType-Request-06-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-07-of-08](./MedicationRequest-INV-C-TimingOnlyOneType-Request-07-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-08-of-08](./MedicationRequest-INV-C-TimingOnlyOneType-Request-08-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-01-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-01-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | mon |  | EVE |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-02-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-02-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  |  | NOON |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-03-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-03-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | fri | 07:00:00 |  |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-04-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-04-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 12:00:00 |  |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-05-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-05-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | wk<br>d | tue |  |  |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-06-of-08](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-06-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-07-of-08](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-07-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-08-of-08](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-08-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |

--- a/input/includes/dosage-constraint-TimingOnlyOneType-examples.md
+++ b/input/includes/dosage-constraint-TimingOnlyOneType-examples.md
@@ -5,22 +5,37 @@
 | [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-03-of-05](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-03-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | fri | 07:00:00 |  |  |
 | [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-04-of-05](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-04-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 12:00:00 |  |  |
 | [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-05-of-05](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-05-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | wk<br>d | tue |  |  |  |
-| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-06-of-08](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-06-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
-| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-07-of-08](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-07-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
-| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-08-of-08](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-08-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-06-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-06-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-07-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-07-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-08-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-08-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-09-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-09-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed | 08:00:00 |  |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-10-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-10-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  |  | MORN |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-11-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-11-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri | 08:00:00 |  |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-12-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-12-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE<br>MORN |  |
+| [MedicationDispense-INV-C-TimingOnlyOneType-Dispense-13-of-13](./MedicationDispense-INV-C-TimingOnlyOneType-Dispense-13-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri | 08:00:00<br>20:00:00 |  |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-01-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-01-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | mon |  | EVE |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-02-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-02-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  |  | NOON |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-03-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-03-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | fri | 07:00:00 |  |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-04-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-04-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 12:00:00 |  |  |
 | [MedicationRequest-INV-C-TimingOnlyOneType-Request-05-of-05](./MedicationRequest-INV-C-TimingOnlyOneType-Request-05-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | wk<br>d | tue |  |  |  |
-| [MedicationRequest-INV-C-TimingOnlyOneType-Request-06-of-08](./MedicationRequest-INV-C-TimingOnlyOneType-Request-06-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
-| [MedicationRequest-INV-C-TimingOnlyOneType-Request-07-of-08](./MedicationRequest-INV-C-TimingOnlyOneType-Request-07-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
-| [MedicationRequest-INV-C-TimingOnlyOneType-Request-08-of-08](./MedicationRequest-INV-C-TimingOnlyOneType-Request-08-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-06-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-06-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-07-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-07-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-08-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-08-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-09-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-09-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed | 08:00:00 |  |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-10-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-10-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  |  | MORN |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-11-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-11-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri | 08:00:00 |  |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-12-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-12-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE<br>MORN |  |
+| [MedicationRequest-INV-C-TimingOnlyOneType-Request-13-of-13](./MedicationRequest-INV-C-TimingOnlyOneType-Request-13-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri | 08:00:00<br>20:00:00 |  |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-01-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-01-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | mon |  | EVE |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-02-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-02-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  |  | NOON |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-03-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-03-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d<br>wk | fri | 07:00:00 |  |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-04-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-04-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 12:00:00 |  |  |
 | [MedicationStatement-INV-C-TimingOnlyOneType-Statement-05-of-05](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-05-of-05.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | wk<br>d | tue |  |  |  |
-| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-06-of-08](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-06-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
-| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-07-of-08](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-07-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
-| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-08-of-08](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-08-of-08.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-06-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-06-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed |  | MORN |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-07-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-07-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  | 08:00:00 |  |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-08-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-08-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-09-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-09-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon<br>wed | 08:00:00 |  |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-10-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-10-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 2 | d |  |  | MORN |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-11-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-11-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri | 08:00:00 |  |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-12-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-12-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri |  | EVE<br>MORN |  |
+| [MedicationStatement-INV-C-TimingOnlyOneType-Statement-13-of-13](./MedicationStatement-INV-C-TimingOnlyOneType-Statement-13-of-13.html) | 1 Stück<br>2 Stück |  |  | 1 | 1<br>3 | wk<br>d | fri | 08:00:00<br>20:00:00 |  |  |

--- a/input/includes/dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md
+++ b/input/includes/dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md
@@ -1,5 +1,8 @@
 | File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [MedicationDispense-INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-01-of-01](./MedicationDispense-INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-01-of-01.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 08:00:00 | MORN |  |
-| [MedicationRequest-INV-C-TimingOnlyWhenOrTimeOfDay-Request-01-of-01](./MedicationRequest-INV-C-TimingOnlyWhenOrTimeOfDay-Request-01-of-01.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 08:00:00 | MORN |  |
-| [MedicationStatement-INV-C-TimingOnlyWhenOrTimeOfDay-Statement-01-of-01](./MedicationStatement-INV-C-TimingOnlyWhenOrTimeOfDay-Statement-01-of-01.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 08:00:00 | MORN |  |
+| [MedicationDispense-INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-01-of-02](./MedicationDispense-INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-01-of-02.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 08:00:00 | MORN |  |
+| [MedicationDispense-INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-02-of-02](./MedicationDispense-INV-C-TimingOnlyWhenOrTimeOfDay-Dispense-02-of-02.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon | 08:00:00 | MORN |  |
+| [MedicationRequest-INV-C-TimingOnlyWhenOrTimeOfDay-Request-01-of-02](./MedicationRequest-INV-C-TimingOnlyWhenOrTimeOfDay-Request-01-of-02.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 08:00:00 | MORN |  |
+| [MedicationRequest-INV-C-TimingOnlyWhenOrTimeOfDay-Request-02-of-02](./MedicationRequest-INV-C-TimingOnlyWhenOrTimeOfDay-Request-02-of-02.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon | 08:00:00 | MORN |  |
+| [MedicationStatement-INV-C-TimingOnlyWhenOrTimeOfDay-Statement-01-of-02](./MedicationStatement-INV-C-TimingOnlyWhenOrTimeOfDay-Statement-01-of-02.html) | 1 Stück<br>1 Stück |  |  | 1 | 1 | d |  | 08:00:00 | MORN |  |
+| [MedicationStatement-INV-C-TimingOnlyWhenOrTimeOfDay-Statement-02-of-02](./MedicationStatement-INV-C-TimingOnlyWhenOrTimeOfDay-Statement-02-of-02.html) | 1 Stück<br>2 Stück |  |  | 1 | 1 | wk | mon | 08:00:00 | MORN |  |

--- a/input/pagecontent/release-notes.md
+++ b/input/pagecontent/release-notes.md
@@ -1,3 +1,31 @@
+### Release: 1.0.5
+
+**What's Changed**
+
+- **Fix für Timing-Schema-Mischungen mit `dayOfWeek`:**
+  - **TimingDgMP**: `TimingOnlyWhenOrTimeOfDay`
+- **Erweiterte Negativbeispiele zur Absicherung gegen Schema-Mischung**
+
+**Details**
+
+- **`TimingOnlyWhenOrTimeOfDay` (`TimingDgMP`)**
+  - Vom Fix betroffene Ressourcentypen: `MedicationRequest`, `MedicationDispense`, `MedicationStatement`
+  - Fix: Die Einschränkung `dayOfWeek.empty()` wurde aus der Schema-Erkennung entfernt. Dadurch wird jetzt auch der Fall korrekt invalidiert, in dem innerhalb einer Ressource `dayOfWeek + timeOfDay` und `dayOfWeek + when` gemischt werden.
+
+- **Testabdeckung für Mischformen von Dosierschemata**
+  - Für `TimingOnlyWhenOrTimeOfDay` wurden Negativbeispiele für alle drei Ressourcentypen um Fälle mit gesetztem `dayOfWeek` ergänzt.
+  - Für `TimingOnlyOneType` wurden zusätzliche Negativbeispiele ergänzt, um Mischungen zusammengesetzter Schemata explizit abzudecken:
+    - reines `dayOfWeek` gemischt mit `dayOfWeek + when`
+    - reines `dayOfWeek` gemischt mit `dayOfWeek + timeOfDay`
+    - reines `Interval` gemischt mit `Interval + when`
+    - reines `Interval` gemischt mit `Interval + timeOfDay`
+    - `dayOfWeek + when` gemischt mit reinem `Interval`
+    - `dayOfWeek + timeOfDay` gemischt mit reinem `Interval`
+    - `dayOfWeek + when` gemischt mit `Interval + when`
+    - `dayOfWeek + timeOfDay` gemischt mit `Interval + timeOfDay`
+
+---
+
 ### Release: 1.0.4
 
 **What's Changed**

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,10 +1,10 @@
 {
-  "package-id" : "de.fhir.medication",
-  "version" : "1.0.4",
-  "path" : "http://ig.fhir.de/igs/medication/1.0.4",
-  "mode" : "milestone",
-  "status" : "release",
-  "sequence" : "STU1",
-  "desc" : "Bug fixes for invariants in TimingDgMP Profile",
-  "first" : false
+  "package-id": "de.fhir.medication",
+  "version": "1.0.5",
+  "path": "http://ig.fhir.de/igs/medication/1.0.5",
+  "mode": "milestone",
+  "status": "release",
+  "sequence": "STU1",
+  "desc": "Fixes TimingDgMP schema detection for dayOfWeek with timeOfDay/when combinations and expands negative test coverage for mixed dosage timing schemas",
+  "first": false
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: MedicationDE
 title: Medication IG DE
 # description: Example Implementation Guide for getting started with SUSHI
 status: active # draft | active | retired | unknown
-version: 1.0.4
+version: 1.0.5
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
 releaseLabel: STU1


### PR DESCRIPTION
This pull request releases version 1.0.5 of the Medication IG DE and addresses a bug in the `TimingDgMP` profile related to the handling of mixed timing schemas involving `dayOfWeek` with `timeOfDay` or `when`. It also significantly expands the set of negative test cases to ensure robust validation against schema mixing. Versioning and documentation have been updated accordingly.

**Bug Fixes and Improvements:**

* **Timing Schema Detection**
  - In `TimingDgMP.fsh`, the constraint requiring `dayOfWeek` to be empty was removed from the `TimingOnlyWhenOrTimeOfDay` logic, fixing improper validation of mixed use of `dayOfWeek` with `timeOfDay` or `when`.

* **Test Coverage**
  - Added comprehensive negative test cases for all three resource types (`MedicationRequest`, `MedicationDispense`, `MedicationStatement`) to cover various combinations and mixtures of timing schema elements, including cases with `dayOfWeek`, `when`, `timeOfDay`, and intervals. [[1]](diffhunk://#diff-00491f08de8fbe62c181cf87bb4fadd74ffa4ae12dce56ce0fee8db5da69abe5R8-R41) [[2]](diffhunk://#diff-963a171c36a40b54e5a41888c9e3928af86f398eddee5f1cc3b87fd7319833c6L3-R8)

**Documentation and Release:**

* **Release Notes**
  - Updated `release-notes.md` to document the bug fix, affected resources, and details of the expanded test coverage for timing schema mixtures.

* **Versioning**
  - Updated version to 1.0.5 in both `sushi-config.yaml` and `publication-request.json`. [[1]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L12-R12) [[2]](diffhunk://#diff-5a1dd5a743b074aee2ee813472f237a649d5c42fb46c9e6fd0bbc66a519755b7L3-R8)
  - Updated package description to reflect the bug fix and expanded test coverage.