### PR TITLE
feat: add invariants to enforce dosage presence when dosage extension…

### DIFF
--- a/input/fsh/examples/constraint_examples_invalid_dosage_extensions_require_dosage.fsh
+++ b/input/fsh/examples/constraint_examples_invalid_dosage_extensions_require_dosage.fsh
@@ -1,0 +1,36 @@
+Instance: INV-C-ExtRequiresDosage-MR-01
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid (Request): dosage extension without dosageInstruction"
+Description: "Invalid: Eine Dosierungs-Extension ist vorhanden, aber keine dosageInstruction."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* extension[+]
+  * url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationRequest.renderedDosageInstruction"
+  * valueMarkdown = "Morgens 1 Tablette"
+
+Instance: INV-C-ExtRequiresDosage-MD-01
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid (Dispense): dosage extension without dosageInstruction"
+Description: "Invalid: Eine Dosierungs-Extension ist vorhanden, aber keine dosageInstruction."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* extension[+]
+  * url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationDispense.renderedDosageInstruction"
+  * valueMarkdown = "Morgens 1 Tablette"
+
+Instance: INV-C-ExtRequiresDosage-MS-01
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid (Statement): dosage extension without dosage"
+Description: "Invalid: Eine Dosierungs-Extension ist vorhanden, aber keine dosage."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* extension[+]
+  * url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationStatement.renderedDosageInstruction"
+  * valueMarkdown = "Morgens 1 Tablette"

--- a/input/fsh/profiles/MedicationDispenseDgMP.fsh
+++ b/input/fsh/profiles/MedicationDispenseDgMP.fsh
@@ -7,6 +7,17 @@ Description: "Dieses Profil dient ausschließlich der Validierung des Implementa
 * extension contains $medicationDispense-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
   and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
+* obeys ExtRequiresDosage-MD-01
 
 * dosageInstruction only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"
+
+Invariant: ExtRequiresDosage-MD-01
+Description: "Wenn eine Dosierungs-Extension (GeneratedDosageInstructionsMeta oder renderedDosageInstruction) vorhanden ist, muss mindestens eine dosageInstruction vorhanden sein."
+Expression: "(
+  extension.where(
+    url = 'http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructionsMeta' or
+    url = 'http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationDispense.renderedDosageInstruction'
+  ).exists()
+) implies dosageInstruction.exists()"
+Severity: #error

--- a/input/fsh/profiles/MedicationRequestDgMP.fsh
+++ b/input/fsh/profiles/MedicationRequestDgMP.fsh
@@ -7,6 +7,17 @@ Description: "Dieses Profil dient ausschließlich der Validierung des Implementa
 * extension contains $medicationRequest-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
   and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
+* obeys ExtRequiresDosage-MR-01
 
 * dosageInstruction only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"
+
+Invariant: ExtRequiresDosage-MR-01
+Description: "Wenn eine Dosierungs-Extension (GeneratedDosageInstructionsMeta oder renderedDosageInstruction) vorhanden ist, muss mindestens eine dosageInstruction vorhanden sein."
+Expression: "(
+  extension.where(
+    url = 'http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructionsMeta' or
+    url = 'http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationRequest.renderedDosageInstruction'
+  ).exists()
+) implies dosageInstruction.exists()"
+Severity: #error

--- a/input/fsh/profiles/MedicationStatementDgMP.fsh
+++ b/input/fsh/profiles/MedicationStatementDgMP.fsh
@@ -7,6 +7,17 @@ Description: "Dieses Profil dient ausschließlich der Validierung des Implementa
 * extension contains $medicationStatement-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
   and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
+* obeys ExtRequiresDosage-MS-01
 
 * dosage only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"
+
+Invariant: ExtRequiresDosage-MS-01
+Description: "Wenn eine Dosierungs-Extension (GeneratedDosageInstructionsMeta oder renderedDosageInstruction) vorhanden ist, muss mindestens eine dosage vorhanden sein."
+Expression: "(
+  extension.where(
+    url = 'http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructionsMeta' or
+    url = 'http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationStatement.renderedDosageInstruction'
+  ).exists()
+) implies dosage.exists()"
+Severity: #error

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -263,6 +263,9 @@ Wenn auf einer MedicationRequest, MedicationDispense oder MedicationStatement di
 **Warum?**
 Die Dosierungs-Extensions enthalten Metadaten beziehungsweise den gerenderten Text zu einer Dosierungsangabe. Ohne Dosierung fehlt ihr fachlicher Bezug. Da es in diesem Fall kein `Dosage`-Objekt gibt, ist die Anforderung als Constraint an den jeweiligen Elternressourcen modelliert.
 
+**Hinweis zur Implementierung:**
+Diese Invariante ist nicht auf den Dosage-Profilen definiert, sondern auf den abstrakten Profilen `MedicationRequestDgMP`, `MedicationDispenseDgMP` und `MedicationStatementDgMP`. Eigene Implementierungsprofile, die nicht von diesen abstrakten dgMP-Profilen ableiten, müssen den jeweils passenden Constraint daher manuell übernehmen.
+
 #### FreeTextMatchesRenderedText
 
 **Beschreibung:**  

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -255,6 +255,14 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-DosageStructuredRequiresGeneratedText-examples.md%}
 
+#### DosageExtensionsRequireDosage
+
+**Beschreibung:**
+Wenn auf einer MedicationRequest, MedicationDispense oder MedicationStatement die Extension `GeneratedDosageInstructionsMeta` oder die für die jeweilige Ressource passende Extension `renderedDosageInstruction` vorliegt, muss die Ressource mindestens eine Dosierung enthalten (`dosageInstruction` bzw. `dosage`).
+
+**Warum?**
+Die Dosierungs-Extensions enthalten Metadaten beziehungsweise den gerenderten Text zu einer Dosierungsangabe. Ohne Dosierung fehlt ihr fachlicher Bezug. Da es in diesem Fall kein `Dosage`-Objekt gibt, ist die Anforderung als Constraint an den jeweiligen Elternressourcen modelliert.
+
 #### FreeTextMatchesRenderedText
 
 **Beschreibung:**  


### PR DESCRIPTION
This pull request introduces a new validation constraint to ensure that a dosage extension is only present when a corresponding dosage is specified in `MedicationRequest`, `MedicationDispense`, or `MedicationStatement` resources. The main changes include the addition of new invariants to the relevant FHIR profiles, example instances demonstrating invalid usage, and updated documentation explaining the constraint.

**Constraint Enforcement in FHIR Profiles:**

* Added invariant `ExtRequiresDosage-MR-01` to `MedicationRequestDgMP`, enforcing that if a dosage extension is present, at least one `dosageInstruction` must exist.
* Added invariant `ExtRequiresDosage-MD-01` to `MedicationDispenseDgMP`, enforcing that if a dosage extension is present, at least one `dosageInstruction` must exist.
* Added invariant `ExtRequiresDosage-MS-01` to `MedicationStatementDgMP`, enforcing that if a dosage extension is present, at least one `dosage` must exist.

**Examples and Documentation:**

* Added invalid example instances in `constraint_examples_invalid_dosage_extensions_require_dosage.fsh` to illustrate the new constraint for each resource type.
* Updated `dosierung-constraints.md` documentation to describe the new constraint, its rationale, and its scope.