### PR TITLE
fix: correct typo in section headings from "Beipiel" to "Beispiel"

### DIFF
--- a/input/pagecontent/schema-tageszeit.md
+++ b/input/pagecontent/schema-tageszeit.md
@@ -6,7 +6,7 @@ In diesem Anwendungsfall wird davon ausgegangen, dass das Arzneimittel (für die
 - die geplante Dauer der Anwendung zu begrenzen (bspw. in Tagen)
 - eine abweichende Dosis abhängig von der Tageszeit anzugeben (in einer weiteren Dosage-Instanz).
 
-### Beipiel
+### Beispiel
 
 {% fragment MedicationRequest/Example-MR-Dosage-1010 JSON %}
 

--- a/input/pagecontent/schema-uhrzeit.md
+++ b/input/pagecontent/schema-uhrzeit.md
@@ -5,7 +5,7 @@ In diesem Anwendungsfall wird davon ausgegangen, dass das Arzneimittel (für die
 - die geplante Dauer der Anwendung zu begrenzen (bspw. in Tagen)
 - eine abweichende Dosis abhängig von der Uhrzeit anzugeben (in einer weiteren Dosage-Instanz).
 
-### Beipiel
+### Beispiel
 
 {% fragment MedicationRequest/Example-MR-Dosage-tod-1t-8am JSON %}
 

--- a/input/pagecontent/schema-wochentag-kombination.md
+++ b/input/pagecontent/schema-wochentag-kombination.md
@@ -6,7 +6,7 @@ In diesem Anwendungsfall wird davon ausgegangen, dass das Arzneimittel wöchentl
 - eine abweichende Dosis abhängig von der Uhrzeit/Tageszeit/Wochentag anzugeben und
 - die geplante Dauer der Anwendung zu begrenzen. 
 
-### Beipiel
+### Beispiel
 
 {% fragment MedicationRequest/Example-MR-Dosage-comb-dayofweek-1 JSON %}
 

--- a/input/pagecontent/schema-wochentag.md
+++ b/input/pagecontent/schema-wochentag.md
@@ -9,7 +9,7 @@ Es konkretisiert dabei nicht, zu welchem Zeitpunkt das Arzneimittel an dem betre
 
 Es wird ermöglicht, die geplante Dauer der Anwendung zu begrenzen.   
 
-### Beipiel
+### Beispiel
 
 {% fragment MedicationRequest/Example-MR-Dosage-weekday-2t JSON %}
 


### PR DESCRIPTION
closes  #109

This pull request corrects a recurring typo in multiple documentation files by changing "Beipiel" to the correct German word "Beispiel" in section headings. This improves the clarity and professionalism of the documentation.

Documentation typo corrections:

* Corrected the typo "Beipiel" to "Beispiel" in the section headings of `schema-tageszeit.md`, `schema-uhrzeit.md`, `schema-wochentag-kombination.md`, and `schema-wochentag.md`. [[1]](diffhunk://#diff-c458d835f442ca38ab9a1d27ced34c12868fd72ff3eaf106c7231c68156b628bL9-R9) [[2]](diffhunk://#diff-aaebd0a75e6f1cb207a9efb871ad0972c976358d3014d1a3f27ca3aa698ba34fL8-R8) [[3]](diffhunk://#diff-337f64faed096d4e574df31191c041a6dc80e284ca293bd8b87e426788103afcL9-R9) [[4]](diffhunk://#diff-e9b5705989d7b7d6dc55d7f24eebab5f230bd190a00d4df8278bc161d228dc0bL12-R12)