### PR TITLE
fix: add correct short description for periodUnit in TimingDgMP

### DIFF
--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -39,6 +39,7 @@ Description: "Beschreibt ein Ereignis, das mehrfach auftreten kann. Zeitpläne w
   * frequencyMax MS
   * period 0..1 MS
   * periodUnit 0..1 MS
+    * ^short = "min | h | d | wk | mo - Zeiteinheit (UCUM)"
   * periodUnit from PeriodUnitsOfTimeDgMPVS (required)
   * periodMax MS
   * dayOfWeek MS


### PR DESCRIPTION
closes #123

This pull request makes a minor update to the `TimingDgMP.fsh` file by adding a short description to the `periodUnit` element. The new description clarifies the allowed units for the period, improving documentation and usability.