### PR TITLE
feat: add constraint for DosageDoseValueDecimalNotation to enforce decimal notation for dosage values

### DIFF
--- a/input/fsh/datatypes/DosageDgMP.fsh
+++ b/input/fsh/datatypes/DosageDgMP.fsh
@@ -8,6 +8,7 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
 * obeys FreeTextSingleDosageOnly
 * obeys FreeTextMatchesRenderedText
 * obeys DosageDoseQuantityAllowedFractions
+* obeys DosageDoseValueDecimalNotation
 * obeys DosageViererschemaInText
 * obeys PatientInstructionIdentical
 * obeys MaxDoseSameUnitAsDose
@@ -229,6 +230,29 @@ doseAndRate.all(
 """
 
 Severity: #error
+
+Invariant: DosageDoseValueDecimalNotation
+Description: "Dosiswerte in doseQuantity oder doseRange müssen in einfacher Dezimalschreibweise mit maximal zwei Nachkommastellen angegeben werden. Die Exponentialschreibweise (z. B. 50e-2 statt 0.5) ist nicht zulässig."
+Expression: """
+doseAndRate.all(
+  (
+    dose.ofType(Quantity).value.empty() or
+    dose.ofType(Quantity).value.toString().matches('^[0-9]+([.][0-9]{1,2})?$')
+  )
+  and
+  (
+    dose.ofType(Range).low.value.empty() or
+    dose.ofType(Range).low.value.toString().matches('^[0-9]+([.][0-9]{1,2})?$')
+  )
+  and
+  (
+    dose.ofType(Range).high.value.empty() or
+    dose.ofType(Range).high.value.toString().matches('^[0-9]+([.][0-9]{1,2})?$')
+  )
+)
+"""
+Severity: #error
+
 Invariant: PatientInstructionIdentical
 Description: "Wenn patientInstruction in einer Ressource mit mehreren Dosierungen verwendet wird, muss das Feld in allen Dosage-Elementen identisch befüllt sein."
 Expression: "(

--- a/input/fsh/examples/constraint_examples_dose_value_notation.fsh
+++ b/input/fsh/examples/constraint_examples_dose_value_notation.fsh
@@ -1,0 +1,46 @@
+// Error examples for DosageDoseValueDecimalNotation
+// The dose value must use plain decimal notation with at most two decimal places.
+// Note: the exponential form (e.g. 50e-2) cannot be authored in FSH, since the FSH
+// number syntax has no exponent. It is covered by the same invariant.
+
+Instance: INV-C-DosageDoseValueDecimalNotation-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Ungültig (Request): Dosiswert mit drei Nachkommastellen"
+Description: "CAVE: Validierungsbeispiel - doseQuantity.value = 0.125 überschreitet die zulässigen zwei Nachkommastellen."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * when[+] = #MORN
+  * doseAndRate.doseQuantity = 0.125 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-DosageDoseValueDecimalNotation-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Ungültig (Dispense): Dosiswert mit drei Nachkommastellen"
+Description: "CAVE: Validierungsbeispiel - doseQuantity.value = 0.125 überschreitet die zulässigen zwei Nachkommastellen."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * when[+] = #MORN
+  * doseAndRate.doseQuantity = 0.125 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-DosageDoseValueDecimalNotation-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Ungültig (Statement): Dosisbereich mit drei Nachkommastellen"
+Description: "CAVE: Validierungsbeispiel - doseRange.low.value = 0.125 überschreitet die zulässigen zwei Nachkommastellen."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * timing.repeat
+    * when[+] = #MORN
+  * doseAndRate.doseRange
+    * low = 0.125 $kbv-dosiereinheit#1 "Stück"
+    * high = 1 $kbv-dosiereinheit#1 "Stück"

--- a/input/fsh/examples/constraint_examples_viererschema.fsh
+++ b/input/fsh/examples/constraint_examples_viererschema.fsh
@@ -1,0 +1,36 @@
+// Error examples for DosageViererschemaInText
+// Dosage.text consists solely of a 4-scheme, which must be modelled structurally in dgMP
+
+Instance: INV-C-DosageViererschemaInText-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Ungültig (Request): reines Viererschema im Freitext"
+Description: "CAVE: Validierungsbeispiel - Dosage.text besteht ausschließlich aus einem Viererschema (1-0-1-0)."
+* status = #active
+* intent = #order
+* subject.display = "Patient"
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * text = "1-0-1-0"
+
+Instance: INV-C-DosageViererschemaInText-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Ungültig (Dispense): reines Viererschema im Freitext"
+Description: "CAVE: Validierungsbeispiel - Dosage.text besteht ausschließlich aus einem Viererschema (1-0-1-0)."
+* status = #completed
+* subject.display = "Patient"
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * text = "1-0-1-0"
+
+Instance: INV-C-DosageViererschemaInText-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Ungültig (Statement): reines Viererschema im Freitext"
+Description: "CAVE: Validierungsbeispiel - Dosage.text besteht ausschließlich aus einem Viererschema mit Einheit (1-0-1-0 Stück)."
+* status = #active
+* subject.display = "Patient"
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * text = "1-0-1-0 Stück"

--- a/input/includes/dosage-constraint-DosageDoseValueDecimalNotation-examples.md
+++ b/input/includes/dosage-constraint-DosageDoseValueDecimalNotation-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-DosageDoseValueDecimalNotation-Dispense-02-of-03](./MedicationDispense-INV-C-DosageDoseValueDecimalNotation-Dispense-02-of-03.html) | 0.125 Stück |  |  |  |  |  |  |  | MORN |  |
+| [MedicationRequest-INV-C-DosageDoseValueDecimalNotation-Request-01-of-03](./MedicationRequest-INV-C-DosageDoseValueDecimalNotation-Request-01-of-03.html) | 0.125 Stück |  |  |  |  |  |  |  | MORN |  |
+| [MedicationStatement-INV-C-DosageDoseValueDecimalNotation-Statement-03-of-03](./MedicationStatement-INV-C-DosageDoseValueDecimalNotation-Statement-03-of-03.html) | 0.125-1 Stück |  |  |  |  |  |  |  | MORN |  |

--- a/input/includes/dosage-constraint-DosageViererschemaInText-examples.md
+++ b/input/includes/dosage-constraint-DosageViererschemaInText-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-DosageViererschemaInText-Dispense-02-of-03](./MedicationDispense-INV-C-DosageViererschemaInText-Dispense-02-of-03.html) |  |  |  |  |  |  |  |  |  |  |
+| [MedicationRequest-INV-C-DosageViererschemaInText-Request-01-of-03](./MedicationRequest-INV-C-DosageViererschemaInText-Request-01-of-03.html) |  |  |  |  |  |  |  |  |  |  |
+| [MedicationStatement-INV-C-DosageViererschemaInText-Statement-03-of-03](./MedicationStatement-INV-C-DosageViererschemaInText-Statement-03-of-03.html) |  |  |  |  |  |  |  |  |  |  |

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -314,6 +314,18 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-DosageDoseUnitSameCode-examples.md%}
 
+#### DosageDoseValueDecimalNotation
+
+**Beschreibung:**  
+Dosiswerte in `doseQuantity.value` sowie `doseRange.low.value` und `doseRange.high.value` müssen in einfacher Dezimalschreibweise mit maximal zwei Nachkommastellen angegeben werden (z. B. `0.5`, `1`, `2.25`). Die vom Datentyp `decimal` erlaubte Exponentialschreibweise ist unzulässig; `0.5` darf also nicht als `50e-2` übermittelt werden.
+
+**Warum?**  
+Der Constraint `DosageDoseQuantityAllowedFractions` schränkt den Wertebereich ein, arbeitet dafür aber auf dem geparsten Zahlenwert und ist gegenüber der Notation blind. Da Dosiswerte in der Praxis auch textnah weiterverarbeitet und angezeigt werden, legt dieser Constraint zusätzlich die Schreibweise fest und hält sie an der BMP-Spezifikation ausgerichtet.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageDoseValueDecimalNotation-examples.md%}
+
 #### DoseRangeHighRequiredWhenLowPresent
 
 **Beschreibung:**  


### PR DESCRIPTION
closes #115
This pull request introduces a new constraint to ensure dose values are consistently formatted in plain decimal notation (with a maximum of two decimal places) and provides validation examples for both this and the "Viererschema" text constraint. The main changes include the definition and documentation of the new `DosageDoseValueDecimalNotation` invariant, as well as the addition of error examples and corresponding documentation tables for both constraints.

**New constraint and validation examples:**

* Added the `DosageDoseValueDecimalNotation` invariant to `DosageDgMP` to require that dose values in `doseQuantity` and `doseRange` use plain decimal notation with at most two decimal places, disallowing exponential notation. [[1]](diffhunk://#diff-219bf3f0dff6d4c6ab325fb0fe503bbb7a74bcc569e2b3b7f05e32793eb0b165R11) [[2]](diffhunk://#diff-219bf3f0dff6d4c6ab325fb0fe503bbb7a74bcc569e2b3b7f05e32793eb0b165R233-R255)
* Added invalid example instances in `constraint_examples_dose_value_notation.fsh` to demonstrate violations of the new decimal notation constraint (e.g., values with three decimal places).
* Added a documentation table summarizing the error examples for the decimal notation constraint in `dosage-constraint-DosageDoseValueDecimalNotation-examples.md`.
* Updated the constraints documentation (`dosierung-constraints.md`) to describe the new constraint, its rationale, and to include the new examples table.

**Viererschema constraint examples:**

* Added error example instances and a documentation table for the `DosageViererschemaInText` constraint, showing cases where dosage text consists solely of a 4-scheme, which is not allowed. [[1]](diffhunk://#diff-7b241557b692b0df6c02ba5430b7e715eeabf7882986f2ea42e91300bd225ecfR1-R36) [[2]](diffhunk://#diff-9f4d7f28f534c226790f9a0ccad87dbcbd756029842ce682b7c7a410e43db690R1-R5)