### PR TITLE
feat: add invalid example notes for non-conformant dosage examples in HTML and CSS

### DIFF
--- a/custom-template/content/assets/css/fhir-ig.css
+++ b/custom-template/content/assets/css/fhir-ig.css
@@ -15,3 +15,17 @@ th, td {
   border: 1px solid black;
   text-align: left !important; /* Align table content left */
 }
+
+/* Notice on intentionally non-conformant examples (ids containing INV- or Unsupported) */
+.invalid-example-note {
+  border-left: 5px solid #ad1f2f;
+  background-color: #f7e7e9;
+  color: #5c1119;
+  padding: 10px 15px;
+  margin: 10px 0 15px 0;
+}
+
+.invalid-example-note a {
+  color: #5c1119;
+  text-decoration: underline;
+}

--- a/custom-template/includes/_append.fragment-intro.html
+++ b/custom-template/includes/_append.fragment-intro.html
@@ -1,0 +1,13 @@
+{% if include.id contains 'Unsupported' %}
+<div class="invalid-example-note">
+  <strong>Hinweis: Dieses Beispiel ist absichtlich nicht konform.</strong>
+  Es zeigt eine Angabe, die in der aktuellen Ausbaustufe des dgMP nicht unterstützt wird, und ist keine Vorlage für eine gültige Dosierungsangabe.
+  Eine Übersicht dieser Beispiele findet sich unter <a href="dosierung-beispiele.html">Beispiele für Dosierungen</a>.
+</div>
+{% elsif include.id contains 'INV-' or include.id contains 'Invalid' %}
+<div class="invalid-example-note">
+  <strong>Hinweis: Dieses Beispiel ist absichtlich nicht valide.</strong>
+  Es dient ausschließlich dazu, die Invarianten dieses Implementation Guides zu prüfen, und ist keine Vorlage für eine gültige Dosierungsangabe.
+  Eine Übersicht der Invarianten mit den zugehörigen Negativbeispielen findet sich unter <a href="dosierung-constraints.html">Übersicht der Timing &amp; Dosierungs-Invarianten</a>.
+</div>
+{% endif %}


### PR DESCRIPTION
closes #129
This pull request introduces a visual notice for intentionally non-conformant examples in the documentation and implements logic to display these notices based on the example's ID. The main changes include the addition of a new CSS class for styling, and conditional logic in the HTML fragment to show appropriate warnings for unsupported or invalid examples.

**Styling updates:**
* Added the `.invalid-example-note` CSS class in `fhir-ig.css` to style notices for intentionally non-conformant examples, including custom border, background, text color, and link styling.

**Template logic enhancements:**
* Updated `_append.fragment-intro.html` to display a warning notice for examples with IDs containing `'Unsupported'`, `'INV-'`, or `'Invalid'`, informing users that these are intentionally non-conformant or invalid, and linking to relevant overview pages.