### PR TITLE
Prepare 2.0.0

### DIFF
--- a/input/fsh/datatypes/DosageDgMP.fsh
+++ b/input/fsh/datatypes/DosageDgMP.fsh
@@ -23,6 +23,11 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
 * obeys VarPeriodNoMindestabstand
 * obeys AsNeededForRequiresAsNeeded
 * obeys AsNeededSingleDosageOnly
+* obeys AsNeededIdentical
+* obeys AsNeededForIdentical
+* obeys MindestabstandIdentical
+* obeys MindestabstandUnitMatchesCode
+* obeys MaxDosePerPeriodIdentical
 * timing only TimingDgMP
 * doseAndRate 0..1 // Nur eine Dosierung für eine Medikation erlauben
   * ^comment = "Begründung Einschränkung Kardinalität: Nur eine Dosierung pro Medikation ist in der ersten Ausbaustufe des dgMP vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
@@ -69,9 +74,14 @@ Description: "Gibt an, wie das Medikament vom Patienten im Kontext dgMP eingenom
       * ^comment = "Indikation für die Bedarfsdosierung."
 * modifierExtension[mindestabstandZwischenGaben]
   * valueDuration 1..1 MS
+    * value 1..1 MS
     * system 1..1 MS
+    * system = $ucum (exactly)
     * code 1..1 MS
+    * code from MindestabstandUnitsOfTimeDgMPVS (required)
     * unit 1..1 MS
+    * comparator 0..0
+      * ^comment = "Begründung Einschränkung Kardinalität: Ein Komparator würde den Mindestabstand unbestimmt machen (z. B. '> 4 Stunden'); die Textgenerierung stellt ausschließlich den exakten Wert dar."
 * site 0..0
   * ^comment = "Begründung Einschränkung Kardinalität: Eine Verabreichungsstelle ist in der aktuellen Ausbaustufe des dgMP nicht vorgesehen, um die Komplexität zu reduzieren und die Übersichtlichkeit zu erhöhen."
 * route 0..0
@@ -109,12 +119,15 @@ Expression: "(%resource.ofType(MedicationRequest).dosageInstruction |
 Severity: #error
 
 Invariant: DosageStructuredRequiresGeneratedText
-Description: "Liegt eine strukturierte Dosierungsangabe vor (timing und doseAndRate belegt, text leer), muss die Extension GeneratedDosageInstructionsMeta vorhanden sein."
+Description: "Liegt eine strukturierte Dosierungsangabe vor (doseAndRate belegt, text leer, dazu timing oder eine reine Bedarfsdosierung), muss die Extension GeneratedDosageInstructionsMeta vorhanden sein."
 Expression: "(
   (%resource.ofType(MedicationRequest).dosageInstruction |
    %resource.ofType(MedicationDispense).dosageInstruction |
    %resource.ofType(MedicationStatement).dosage
-  ).exists(timing.exists() and doseAndRate.exists() and text.empty())
+  ).exists(
+    text.empty() and doseAndRate.exists() and
+    (timing.exists() or asNeeded.ofType(boolean) = true)
+  )
 )
 implies
 (
@@ -404,3 +417,234 @@ Invariant: MaxDoseOnlyWhenAsNeeded
 Description: "Eine Maximalmenge (maxDosePerPeriod) darf nur bei einer Bedarfsdosierung (asNeededBoolean=true) angegeben werden."
 Severity: #error
 Expression: "maxDosePerPeriod.empty() or asNeeded.ofType(boolean) = true"
+
+// --- Konsistenz der Rahmen-Angaben über mehrere Dosage-Elemente ---
+// Die Textgenerierung liest Bedarfskennzeichen, Einnahmeanlass, Mindestabstand und
+// Maximalmenge ausschließlich aus dem ersten Dosage-Element. Ohne die folgenden
+// Invarianten könnten abweichende Angaben in weiteren Elementen unbemerkt entfallen.
+
+Invariant: AsNeededIdentical
+Description: "Das Bedarfskennzeichen (asNeededBoolean) muss über alle Dosage-Elemente einer Ressource identisch befüllt sein."
+Severity: #error
+Expression: "(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).asNeeded.ofType(boolean).distinct().count() <= 1
+)
+and
+(
+  (
+    (
+      %resource.ofType(MedicationRequest).dosageInstruction |
+      %resource.ofType(MedicationDispense).dosageInstruction |
+      %resource.ofType(MedicationStatement).dosage
+    ).asNeeded.ofType(boolean).exists()
+  )
+  implies
+  (
+    (
+      %resource.ofType(MedicationRequest).dosageInstruction |
+      %resource.ofType(MedicationDispense).dosageInstruction |
+      %resource.ofType(MedicationStatement).dosage
+    ).all(asNeeded.ofType(boolean).exists())
+  )
+)"
+
+Invariant: AsNeededForIdentical
+Description: "Der Einnahmeanlass (asNeededFor) muss über alle Dosage-Elemente einer Ressource identisch befüllt sein. Mehrere Anlässe je Element sind zulässig, müssen dann aber in allen Elementen übereinstimmen."
+Severity: #error
+/* Jedes Dosage-Element muss genauso viele verschiedene Anlässe tragen wie die
+   Ressource insgesamt. Zwei Mengen gleicher Mächtigkeit, deren Vereinigung
+   dieselbe Mächtigkeit hat, sind identisch — unabhängig von der Reihenfolge. */
+Expression: "(
+  %resource.ofType(MedicationRequest).dosageInstruction |
+  %resource.ofType(MedicationDispense).dosageInstruction |
+  %resource.ofType(MedicationStatement).dosage
+).all(
+  extension.where(
+    url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor'
+  ).value.ofType(CodeableConcept).text.distinct().count()
+  =
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).extension.where(
+    url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor'
+  ).value.ofType(CodeableConcept).text.distinct().count()
+)"
+
+Invariant: MindestabstandIdentical
+Description: "Der Mindestabstand zwischen Gaben muss über alle Dosage-Elemente einer Ressource identisch befüllt sein."
+Severity: #error
+/* Die distinct()-Prüfungen allein genügen nicht: Ein Element, das value oder code
+   nicht mit einem tatsächlichen primitiven Wert belegt, steuert keinen vergleichbaren
+   Wert zur Menge bei und könnte unbemerkt bleiben. Deshalb muss jede vorhandene
+   Extension genau einen tatsächlichen Wert und einen tatsächlichen Code beitragen.
+   hasValue() ist nötig, weil ein FHIR-Primitive auch ohne eigenen Wert existieren
+   kann, wenn es lediglich eine Extension trägt. */
+Expression: "(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).modifierExtension.where(
+    url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+  ).value.ofType(Duration).value.where($this.hasValue()).count()
+  =
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).modifierExtension.where(
+    url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+  ).count()
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).modifierExtension.where(
+    url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+  ).value.ofType(Duration).code.where($this.hasValue()).count()
+  =
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).modifierExtension.where(
+    url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+  ).count()
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).modifierExtension.where(
+    url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+  ).value.ofType(Duration).value.distinct().count() <= 1
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).modifierExtension.where(
+    url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+  ).value.ofType(Duration).code.distinct().count() <= 1
+)
+and
+(
+  (
+    (
+      %resource.ofType(MedicationRequest).dosageInstruction |
+      %resource.ofType(MedicationDispense).dosageInstruction |
+      %resource.ofType(MedicationStatement).dosage
+    ).modifierExtension.where(
+      url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+    ).exists()
+  )
+  implies
+  (
+    (
+      %resource.ofType(MedicationRequest).dosageInstruction |
+      %resource.ofType(MedicationDispense).dosageInstruction |
+      %resource.ofType(MedicationStatement).dosage
+    ).all(
+      modifierExtension.where(
+        url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+      ).exists()
+    )
+  )
+)"
+
+Invariant: MindestabstandUnitMatchesCode
+Description: "Die Anzeigeeinheit des Mindestabstands (valueDuration.unit) muss zum UCUM-Code passen (z. B. 'Stunde(n)' nur mit code='h')."
+Severity: #error
+Expression: "modifierExtension.where(
+  url='http://ig.fhir.de/igs/medication/StructureDefinition/MindestabstandZwischenGaben'
+).value.ofType(Duration).all(
+  (
+    code = 'min'
+    implies
+    (unit = 'Minute(n)' or unit = 'Minute' or unit = 'Minuten')
+  ) and (
+    code = 'h'
+    implies
+    (unit = 'Stunde(n)' or unit = 'Stunde' or unit = 'Stunden')
+  )
+)"
+
+Invariant: MaxDosePerPeriodIdentical
+Description: "Die Maximalmenge (maxDosePerPeriod) gilt für die Gesamtmenge im Bezugszeitraum und muss über alle Dosage-Elemente einer Ressource identisch befüllt sein."
+Severity: #error
+/* Wie bei MindestabstandIdentical genügen die distinct()-Prüfungen allein nicht:
+   Ein Element, das ein Teilfeld gar nicht belegt, steuert nichts zur Menge bei.
+   Deshalb muss jede vorhandene Maximalmenge alle vier Teilfelder führen. */
+Expression: "(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).maxDosePerPeriod.all(
+    numerator.value.hasValue() and numerator.unit.hasValue() and
+    denominator.value.hasValue() and denominator.code.hasValue()
+  )
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).maxDosePerPeriod.numerator.value.distinct().count() <= 1
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).maxDosePerPeriod.numerator.unit.distinct().count() <= 1
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).maxDosePerPeriod.denominator.value.distinct().count() <= 1
+)
+and
+(
+  (
+    %resource.ofType(MedicationRequest).dosageInstruction |
+    %resource.ofType(MedicationDispense).dosageInstruction |
+    %resource.ofType(MedicationStatement).dosage
+  ).maxDosePerPeriod.denominator.code.distinct().count() <= 1
+)
+and
+(
+  (
+    (
+      %resource.ofType(MedicationRequest).dosageInstruction |
+      %resource.ofType(MedicationDispense).dosageInstruction |
+      %resource.ofType(MedicationStatement).dosage
+    ).maxDosePerPeriod.exists()
+  )
+  implies
+  (
+    (
+      %resource.ofType(MedicationRequest).dosageInstruction |
+      %resource.ofType(MedicationDispense).dosageInstruction |
+      %resource.ofType(MedicationStatement).dosage
+    ).all(maxDosePerPeriod.exists())
+  )
+)"

--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -409,7 +409,7 @@ Expression: "( /* Detect DayOfWeek */
 Severity: #error
 
 Invariant: TimingOnlyOneBounds
-Description: "Dosages Timings must state the same bounds duration across multiple dosage instances"
+Description: "Dosages Timings must state the same bounds (Duration or Period) across multiple dosage instances"
 Expression: "(
   %resource.ofType(MedicationRequest).dosageInstruction
   | %resource.ofType(MedicationDispense).dosageInstruction
@@ -435,6 +435,29 @@ Expression: "(
         (%resource.dosage.timing.repeat.bounds.ofType(Duration).value.distinct().count() = 1)
         and
         (%resource.dosage.timing.repeat.bounds.ofType(Duration).code.distinct().count() = 1)
+      )
+    )
+    and
+    ( /* boundsPeriod: Start und Ende müssen ebenfalls über alle Dosierungen gleich sein.
+         Die Textgenerierung liest den Zeitrahmen nur aus dem ersten Dosage-Element. */
+      (%resource.ofType(MedicationRequest).exists() or %resource.ofType(MedicationDispense).exists())
+      implies
+      %resource.dosageInstruction.timing.repeat.bounds.ofType(Period).exists().not() or
+      (
+        (%resource.dosageInstruction.timing.repeat.bounds.ofType(Period).start.distinct().count() <= 1)
+        and
+        (%resource.dosageInstruction.timing.repeat.bounds.ofType(Period).end.distinct().count() <= 1)
+      )
+    )
+    and
+    (
+      %resource.ofType(MedicationStatement).exists()
+      implies
+      %resource.dosage.timing.repeat.bounds.ofType(Period).exists().not() or
+      (
+        (%resource.dosage.timing.repeat.bounds.ofType(Period).start.distinct().count() <= 1)
+        and
+        (%resource.dosage.timing.repeat.bounds.ofType(Period).end.distinct().count() <= 1)
       )
     )
   )

--- a/input/fsh/examples/constraint_examples_invalid_frame_consistency.fsh
+++ b/input/fsh/examples/constraint_examples_invalid_frame_consistency.fsh
@@ -1,0 +1,324 @@
+// Invalid examples for the frame-consistency constraints in DosageDgMP.
+// Die Textgenerierung liest Bedarfskennzeichen, Einnahmeanlass, Mindestabstand und
+// Maximalmenge ausschließlich aus dem ersten Dosage-Element. Weichen weitere Elemente
+// ab, entfiele die Angabe unbemerkt — diese Beispiele decken die Prüfung dagegen ab.
+// Coverage target: Request, Dispense, Statement for each constraint
+
+// ---------------------------------------------------------------------------
+// AsNeededIdentical
+// ---------------------------------------------------------------------------
+
+Instance: INV-C-AsNeededIdentical-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: asNeededBoolean differs between dosages"
+Description: "CAVE: Validation example - nur das erste Dosage-Element ist als Bedarfsmedikation gekennzeichnet; das zweite nicht."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-AsNeededIdentical-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid: asNeededBoolean differs between dosages"
+Description: "CAVE: Validation example - nur das erste Dosage-Element ist als Bedarfsmedikation gekennzeichnet; das zweite nicht."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-AsNeededIdentical-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid: asNeededBoolean differs between dosages"
+Description: "CAVE: Validation example - nur das erste Dosage-Element ist als Bedarfsmedikation gekennzeichnet; das zweite nicht."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosage[+]
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+// ---------------------------------------------------------------------------
+// AsNeededForIdentical
+// ---------------------------------------------------------------------------
+
+Instance: INV-C-AsNeededForIdentical-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: asNeededFor differs between dosages"
+Description: "CAVE: Validation example - der Einnahmeanlass ist nur im ersten Dosage-Element angegeben und ginge im erzeugten Text verloren."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * extension[asNeededFor].valueCodeableConcept.text = "Kopfschmerzen"
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-AsNeededForIdentical-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid: asNeededFor differs between dosages"
+Description: "CAVE: Validation example - der Einnahmeanlass ist nur im ersten Dosage-Element angegeben und ginge im erzeugten Text verloren."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * extension[asNeededFor].valueCodeableConcept.text = "Kopfschmerzen"
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-AsNeededForIdentical-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid: asNeededFor differs between dosages"
+Description: "CAVE: Validation example - der Einnahmeanlass ist nur im ersten Dosage-Element angegeben und ginge im erzeugten Text verloren."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * asNeededBoolean = true
+  * extension[asNeededFor].valueCodeableConcept.text = "Kopfschmerzen"
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosage[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+// ---------------------------------------------------------------------------
+// MindestabstandIdentical
+// ---------------------------------------------------------------------------
+
+Instance: INV-C-MindestabstandIdentical-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: Mindestabstand differs between dosages"
+Description: "CAVE: Validation example - der Mindestabstand zwischen Gaben ist nur im ersten Dosage-Element angegeben."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * modifierExtension[mindestabstandZwischenGaben].valueDuration = 4 $ucum#h "Stunde(n)"
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-MindestabstandIdentical-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid: Mindestabstand differs between dosages"
+Description: "CAVE: Validation example - der Mindestabstand zwischen Gaben ist nur im ersten Dosage-Element angegeben."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * modifierExtension[mindestabstandZwischenGaben].valueDuration = 4 $ucum#h "Stunde(n)"
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-MindestabstandIdentical-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid: Mindestabstand differs between dosages"
+Description: "CAVE: Validation example - der Mindestabstand zwischen Gaben ist nur im ersten Dosage-Element angegeben."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * asNeededBoolean = true
+  * modifierExtension[mindestabstandZwischenGaben].valueDuration = 4 $ucum#h "Stunde(n)"
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosage[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+// ---------------------------------------------------------------------------
+// MindestabstandUnitMatchesCode
+// ---------------------------------------------------------------------------
+
+Instance: INV-C-MindestabstandUnitMatchesCode-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: Mindestabstand unit does not match code"
+Description: "CAVE: Validation example - valueDuration.code ist 'h', die Anzeigeeinheit lautet aber 'Tag(e)'."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * modifierExtension[mindestabstandZwischenGaben].valueDuration = 4 $ucum#h "Tag(e)"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-MindestabstandUnitMatchesCode-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid: Mindestabstand unit does not match code"
+Description: "CAVE: Validation example - valueDuration.code ist 'h', die Anzeigeeinheit lautet aber 'Tag(e)'."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * modifierExtension[mindestabstandZwischenGaben].valueDuration = 4 $ucum#h "Tag(e)"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+
+Instance: INV-C-MindestabstandUnitMatchesCode-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid: Mindestabstand unit does not match code"
+Description: "CAVE: Validation example - valueDuration.code ist 'h', die Anzeigeeinheit lautet aber 'Tag(e)'."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * asNeededBoolean = true
+  * modifierExtension[mindestabstandZwischenGaben].valueDuration = 4 $ucum#h "Tag(e)"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+
+// ---------------------------------------------------------------------------
+// MaxDosePerPeriodIdentical
+// ---------------------------------------------------------------------------
+
+Instance: INV-C-MaxDosePerPeriodIdentical-Request-01-of-03
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Invalid: maxDosePerPeriod differs between dosages"
+Description: "CAVE: Validation example - die Maximalmenge gilt für die Gesamtmenge im Bezugszeitraum, ist hier aber je Dosage-Element unterschiedlich angegeben."
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * maxDosePerPeriod.numerator.value = 6
+  * maxDosePerPeriod.numerator.system = $kbv-dosiereinheit
+  * maxDosePerPeriod.numerator.code = #1
+  * maxDosePerPeriod.numerator.unit = "Stück"
+  * maxDosePerPeriod.denominator.value = 24
+  * maxDosePerPeriod.denominator.system = $ucum
+  * maxDosePerPeriod.denominator.code = #h
+  * maxDosePerPeriod.denominator.unit = "Stunde(n)"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * maxDosePerPeriod.numerator.value = 8
+  * maxDosePerPeriod.numerator.system = $kbv-dosiereinheit
+  * maxDosePerPeriod.numerator.code = #1
+  * maxDosePerPeriod.numerator.unit = "Stück"
+  * maxDosePerPeriod.denominator.value = 24
+  * maxDosePerPeriod.denominator.system = $ucum
+  * maxDosePerPeriod.denominator.code = #h
+  * maxDosePerPeriod.denominator.unit = "Stunde(n)"
+
+Instance: INV-C-MaxDosePerPeriodIdentical-Dispense-02-of-03
+InstanceOf: MedicationDispenseDgMP
+Usage: #example
+Title: "Invalid: maxDosePerPeriod differs between dosages"
+Description: "CAVE: Validation example - die Maximalmenge gilt für die Gesamtmenge im Bezugszeitraum, ist hier aber je Dosage-Element unterschiedlich angegeben."
+* subject.display = "Patient"
+* status = #completed
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * maxDosePerPeriod.numerator.value = 6
+  * maxDosePerPeriod.numerator.system = $kbv-dosiereinheit
+  * maxDosePerPeriod.numerator.code = #1
+  * maxDosePerPeriod.numerator.unit = "Stück"
+  * maxDosePerPeriod.denominator.value = 24
+  * maxDosePerPeriod.denominator.system = $ucum
+  * maxDosePerPeriod.denominator.code = #h
+  * maxDosePerPeriod.denominator.unit = "Stunde(n)"
+* dosageInstruction[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * maxDosePerPeriod.numerator.value = 8
+  * maxDosePerPeriod.numerator.system = $kbv-dosiereinheit
+  * maxDosePerPeriod.numerator.code = #1
+  * maxDosePerPeriod.numerator.unit = "Stück"
+  * maxDosePerPeriod.denominator.value = 24
+  * maxDosePerPeriod.denominator.system = $ucum
+  * maxDosePerPeriod.denominator.code = #h
+  * maxDosePerPeriod.denominator.unit = "Stunde(n)"
+
+Instance: INV-C-MaxDosePerPeriodIdentical-Statement-03-of-03
+InstanceOf: MedicationStatementDgMP
+Usage: #example
+Title: "Invalid: maxDosePerPeriod differs between dosages"
+Description: "CAVE: Validation example - die Maximalmenge gilt für die Gesamtmenge im Bezugszeitraum, ist hier aber je Dosage-Element unterschiedlich angegeben."
+* subject.display = "Patient"
+* status = #active
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosage[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #MORN
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+  * maxDosePerPeriod.numerator.value = 6
+  * maxDosePerPeriod.numerator.system = $kbv-dosiereinheit
+  * maxDosePerPeriod.numerator.code = #1
+  * maxDosePerPeriod.numerator.unit = "Stück"
+  * maxDosePerPeriod.denominator.value = 24
+  * maxDosePerPeriod.denominator.system = $ucum
+  * maxDosePerPeriod.denominator.code = #h
+  * maxDosePerPeriod.denominator.unit = "Stunde(n)"
+* dosage[+]
+  * asNeededBoolean = true
+  * timing.repeat.when = #EVE
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+  * maxDosePerPeriod.numerator.value = 8
+  * maxDosePerPeriod.numerator.system = $kbv-dosiereinheit
+  * maxDosePerPeriod.numerator.code = #1
+  * maxDosePerPeriod.numerator.unit = "Stück"
+  * maxDosePerPeriod.denominator.value = 24
+  * maxDosePerPeriod.denominator.system = $ucum
+  * maxDosePerPeriod.denominator.code = #h
+  * maxDosePerPeriod.denominator.unit = "Stunde(n)"

--- a/input/fsh/terminologies/MindestabstandUnitsOfTimeDgMP-VS.fsh
+++ b/input/fsh/terminologies/MindestabstandUnitsOfTimeDgMP-VS.fsh
@@ -1,0 +1,10 @@
+ValueSet: MindestabstandUnitsOfTimeDgMPVS
+Id: MindestabstandUnitsOfTimeDgMP
+Title: "Mindestabstand UnitsOfTime dgMP ValueSet"
+Description: "Dieses ValueSet enthält die für den Mindestabstand zwischen zwei Einzelgaben zulässigen Zeiteinheiten aus dem UCUM-CodeSystem in deutscher Übersetzung"
+* include $ucum#min
+  * ^designation.language = #de-DE
+  * ^designation.value = "Minute(n)"
+* include $ucum#h
+  * ^designation.language = #de-DE
+  * ^designation.value = "Stunde(n)"

--- a/input/includes/dosage-constraint-AsNeededForIdentical-examples.md
+++ b/input/includes/dosage-constraint-AsNeededForIdentical-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-AsNeededForIdentical-Dispense-02-of-03](./MedicationDispense-INV-C-AsNeededForIdentical-Dispense-02-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationRequest-INV-C-AsNeededForIdentical-Request-01-of-03](./MedicationRequest-INV-C-AsNeededForIdentical-Request-01-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationStatement-INV-C-AsNeededForIdentical-Statement-03-of-03](./MedicationStatement-INV-C-AsNeededForIdentical-Statement-03-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |

--- a/input/includes/dosage-constraint-AsNeededIdentical-examples.md
+++ b/input/includes/dosage-constraint-AsNeededIdentical-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-AsNeededIdentical-Dispense-02-of-03](./MedicationDispense-INV-C-AsNeededIdentical-Dispense-02-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationRequest-INV-C-AsNeededIdentical-Request-01-of-03](./MedicationRequest-INV-C-AsNeededIdentical-Request-01-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationStatement-INV-C-AsNeededIdentical-Statement-03-of-03](./MedicationStatement-INV-C-AsNeededIdentical-Statement-03-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |

--- a/input/includes/dosage-constraint-MaxDosePerPeriodIdentical-examples.md
+++ b/input/includes/dosage-constraint-MaxDosePerPeriodIdentical-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-MaxDosePerPeriodIdentical-Dispense-02-of-03](./MedicationDispense-INV-C-MaxDosePerPeriodIdentical-Dispense-02-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationRequest-INV-C-MaxDosePerPeriodIdentical-Request-01-of-03](./MedicationRequest-INV-C-MaxDosePerPeriodIdentical-Request-01-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationStatement-INV-C-MaxDosePerPeriodIdentical-Statement-03-of-03](./MedicationStatement-INV-C-MaxDosePerPeriodIdentical-Statement-03-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |

--- a/input/includes/dosage-constraint-MindestabstandIdentical-examples.md
+++ b/input/includes/dosage-constraint-MindestabstandIdentical-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-MindestabstandIdentical-Dispense-02-of-03](./MedicationDispense-INV-C-MindestabstandIdentical-Dispense-02-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationRequest-INV-C-MindestabstandIdentical-Request-01-of-03](./MedicationRequest-INV-C-MindestabstandIdentical-Request-01-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |
+| [MedicationStatement-INV-C-MindestabstandIdentical-Statement-03-of-03](./MedicationStatement-INV-C-MindestabstandIdentical-Statement-03-of-03.html) | 1 Stück<br>2 Stück |  |  |  |  |  |  |  | MORN<br>EVE |  |

--- a/input/includes/dosage-constraint-MindestabstandUnitMatchesCode-examples.md
+++ b/input/includes/dosage-constraint-MindestabstandUnitMatchesCode-examples.md
@@ -1,0 +1,5 @@
+| File | doseQuantity | duration | durationUnit | frequency | period | periodUnit | Day<br>of<br>Week | Time<br>Of<br>Day | when | bounds[x] |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [MedicationDispense-INV-C-MindestabstandUnitMatchesCode-Dispense-02-of-03](./MedicationDispense-INV-C-MindestabstandUnitMatchesCode-Dispense-02-of-03.html) | 1 Stück |  |  |  |  |  |  |  |  |  |
+| [MedicationRequest-INV-C-MindestabstandUnitMatchesCode-Request-01-of-03](./MedicationRequest-INV-C-MindestabstandUnitMatchesCode-Request-01-of-03.html) | 1 Stück |  |  |  |  |  |  |  |  |  |
+| [MedicationStatement-INV-C-MindestabstandUnitMatchesCode-Statement-03-of-03](./MedicationStatement-INV-C-MindestabstandUnitMatchesCode-Statement-03-of-03.html) | 1 Stück |  |  |  |  |  |  |  |  |  |

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -1,285 +1,26 @@
-Im Folgenden werden alle definierten Invarianten für das Timing-Profil aufgelistet, jeweils mit einer kurzen Beschreibung und der Begründung für ihre Existenz. Diese Regeln sorgen für eine konsistente und eindeutige Modellierung von Dosierungszeitpunkten im FHIR-Kontext.
+Auf dieser Seite sind alle Invarianten dieses Implementation Guides aufgeführt, jeweils mit einer kurzen Beschreibung, der Begründung für ihre Existenz und Beispielen, die die Regel verletzen beziehungsweise auslösen.
 
-Neben den Timing-bezogenen Regeln existieren weitere Invarianten auf Ebene des Dosage-Elements (Profil `DosageDE` bzw. `DosageDgMP`). Diese steuern, wie strukturierte und Freitext‑Dosierungen zulässig kombiniert werden und stellen Konsistenz bei Dosiereinheiten sicher. Alle aktuell definierten Constraints sind nachfolgend aufgeführt.
+Die Gliederung folgt den beiden Profilfamilien und innerhalb davon dem Schweregrad. Da die dgMP-Profile von den DE-Profilen erben, gelten die Regeln der DE-Profile in beiden Welten; die dgMP-Profile fügen weitere Regeln hinzu und fassen mehrere Sachverhalte strenger. Wo es zu einer Warnung eine strengere dgMP-Entsprechung gibt, ist sie im jeweiligen Abschnitt verlinkt.
 
-### Timing-bezogene Constraints
+### DE-Profile
 
-#### TimingFrequencyCount
+Die folgenden Invarianten sind auf den generischen Profilen [DosageDE](./StructureDefinition-DosageDE.html) und [TimingDE](./StructureDefinition-TimingDE.html) definiert. Sie gelten für alle Ressourcen nach diesen Profilen und - über die Vererbung - ebenso für Ressourcen nach den dgMP-Profilen.
 
-**Beschreibung:**  
-Wenn die Häufigkeit (`frequency`) angegeben ist, muss sie mit der Anzahl der angegebenen Zeitpunkte (`timeOfDay` oder `when`) übereinstimmen, abhängig davon, welche Felder gesetzt sind.
+#### Warnungen
 
-**Warum?**  
-Diese Regel stellt sicher, dass die Anzahl der Dosierungen pro Periode korrekt mit den angegebenen Zeitpunkten übereinstimmt, wenn `frequency` explizit angegeben wird. So wird verhindert, dass widersprüchliche oder unklare Dosierungsangaben entstehen.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingFrequencyCount-examples.md%}
-
-#### TimingPeriodUnit
+##### DosageStructuredOrFreeTextWarning
 
 **Beschreibung:**  
-Wenn `periodUnit` angegeben ist und Wochentage (`dayOfWeek`) angegeben sind, muss die Zeiteinheit (`periodUnit`) „Woche“ (`wk`) sein; andernfalls muss sie „Tag“ (`d`) sein.
+Warnung in `DosageDE`, wenn eine Dosierungsangabe strukturierte Elemente (`timing`, `doseAndRate`) und Freitext (`text`) mischt.
 
 **Warum?**  
-Dadurch wird sichergestellt, dass die Zeiteinheit zur Angabe der Dosierungsperiode konsistent zu den verwendeten Feldern passt und keine Missverständnisse bei der Interpretation entstehen.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingPeriodUnit-examples.md%}
-
-#### TimingOnlyOneType
-
-**Beschreibung:**  
-Es darf pro Dosierung nur eine Art der Zeitangabe verwendet werden (z.B. ausschließlich `4-Schema`, `TimeOfDay`, `DayOfWeek`, `Interval`, Kombinationen wie `DayOfWeek+TimeOfDay` oder `Interval+TimeOfDay`).
-
-**Warum?**  
-Diese Einschränkung verhindert Mehrdeutigkeiten und sorgt dafür, dass die Dosierungszeitpunkte eindeutig interpretierbar bleiben.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOneType-examples.md%}
-
-#### TimingOnlyOneWhen
-
-**Beschreibung:**  
-Es darf nicht derselbe Zeitraum des Tages (`when`) in mehreren Dosierungsinstanzen vorkommen.
-
-**Warum?**  
-Dadurch wird verhindert, dass Dosierungen mehrfach für denselben Zeitraum angegeben werden, was zu Überdosierung oder Verwirrung führen könnte.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOneWhen-examples.md%}
-
-#### TimingOnlyWhenOrTimeOfDay
-
-**Beschreibung:**  
-Es darf nicht die Tageszeit `timeOfDay` und der Zeitraum des Tages `when` in mehreren Dosierungsinstanzen gleichzeitig vorkommen.
-
-**Warum?**  
-Dadurch wird verhindert, dass Dosierungen gemischte Schemata anzeigen.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md%}
-
-#### TimingOnlyOneTimeOfDay
-
-**Beschreibung:**  
-Es darf nicht dieselbe Tageszeit (`timeOfDay`) in mehreren Dosierungsinstanzen vorkommen.
-
-**Warum?**  
-Auch hier wird sichergestellt, dass Dosierungen nicht mehrfach für dieselbe Uhrzeit definiert werden, um Redundanzen und Fehler zu vermeiden.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOneTimeOfDay-examples.md%}
-
-#### TimingOnlyOneDayOfWeek
-
-**Beschreibung:**  
-Es darf nicht derselbe Wochentag (`dayOfWeek`) in mehreren Dosierungsinstanzen vorkommen.
-
-**Warum?**  
-Dies verhindert doppelte Einträge für denselben Wochentag und stellt eine eindeutige Zuordnung sicher.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOneDayOfWeek-examples.md%}
-
-#### TimingOnlyOneBounds
-
-**Beschreibung:**  
-Für die Dauer (`bounds` vom Typ `Duration`) dürfen pro Ressource nur ein Wert und ein Code vorkommen.
-
-**Warum?**  
-So wird ausgeschlossen, dass mehrere unterschiedliche Zeiträume für eine Dosierung angegeben werden, was die Interpretation erschweren würde.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOneBounds-examples.md%}
-
-#### TimingBoundsDurationOnlyWholeNumber
-
-**Beschreibung:**  
-Der Wert der Gesamtdauer (`boundsDuration.value`) darf nur Ganzzahlen enthalten, Nachkommastellen sind nicht zulässig.
-
-**Warum?**  
-Verhindert unklare oder technisch nicht sinnvolle Angaben einer Behandlungsdauer mit Bruchteilen von Zeiteinheiten (z. B. „1,5 Tage“) und sorgt für konsistente, eindeutig interpretierbare Zeiträume.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingBoundsDurationOnlyWholeNumber-examples.md%}
-
-#### TimingIntervalOnlyOneFrequency
-
-**Beschreibung:**  
-Bei Intervallangaben darf es nur eine Dosierungsinstanz geben.
-
-**Warum?**  
-Dadurch wird verhindert, dass ein Intervall mehrfach beschrieben wird, was zu widersprüchlichen Angaben führen könnte.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingIntervalOnlyOneFrequency-examples.md%}
-
-#### TimingOnlyOnePeriodForDayOfWeek
-
-**Beschreibung:**  
-Wenn für einen Wochentag mehrere Einträge existieren, müssen sich deren Zeitangaben (`when`/`timeOfDay`) unterscheiden.
-
-**Warum?**  
-Dies stellt sicher, dass für jeden Wochentag die Dosierungszeitpunkte eindeutig sind und keine Dopplungen auftreten.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOnePeriodForDayOfWeek-examples.md%}
-
-#### TimingOnlyOneTimeForInterval
-
-**Beschreibung:**  
-Bei Intervallangaben mit Zeitpunkten (`when` oder `timeOfDay`) dürfen die Zeitangaben nicht mehrfach vorkommen und die Periodenangaben müssen eindeutig sein.
-
-**Warum?**  
-Damit wird verhindert, dass für ein Intervall mehrere widersprüchliche Zeitpunkte oder Perioden definiert werden.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingOnlyOneTimeForInterval-examples.md%}
-
-#### TimingBoundsUnitMatchesCodeWarning
-
-**Beschreibung:**  
-Warnung in `TimingDE`, wenn die Einheit (`boundsDuration.unit`) nicht zum UCUM‑Code (`boundsDuration.code`) passt.
-
-**Warum?**  
-Widersprüchliche Angaben wie `code='wk'` mit `unit='Tag(e)'` sind fast immer ein Fehler, die Einheit ist im generischen Profil aber nicht auf die deutschen Bezeichnungen festgelegt. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [TimingBoundsUnitMatchesCode](#timingboundsunitmatchescode).
+Verhindert widersprüchliche oder doppelte Informationsquellen (Freitext vs. Struktur) und erleichtert die automatische Verarbeitung. Implementierungen sollten die strukturierte Variante bevorzugen und Freitext nur verwenden, wenn eine strukturierte Abbildung nicht möglich ist. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [DosageStructuredOrFreeText](#dosagestructuredorfreetext).
 
 Folgende Beispiele lösen eine Warnung aus:
-
-{% include dosage-constraint-TimingBoundsUnitMatchesCodeWarning-examples.md%}
-
-#### TimingBoundsUnitMatchesCode
-
-**Beschreibung:**  
-In den dgMP-Profilen muss die Einheit (`boundsDuration.unit`) zum UCUM‑Code (`boundsDuration.code`) passen; z. B. `wk` nur mit „Woche(n)“, `d` nur mit „Tag(e)“, `mo` nur mit „Monat(e)“, `a` nur mit „Jahr(e)“.
-
-**Warum?**  
-Die Textgenerierung leitet die Zeiteinheit aus dem Code ab; eine abweichende `unit` würde eine Dauer anzeigen, die nicht der übermittelten entspricht.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingBoundsUnitMatchesCode-examples.md%}
-
-#### TimingSingleDosageForTimeOfDayWarning
-
-**Beschreibung:**  
-Warnung in `TimingDE`, wenn bei täglicher Dosierung mit ausschließlich `timeOfDay` mehrere `Dosage`‑Elemente mit identischer Dosis verwendet werden.
-
-**Warum?**  
-Mehrere gleichartige Elemente sind unnötig aufgesplittert und erschweren die Auswertung. Im generischen Profil bleibt es bei einer Warnung, weil die Aufteilung dort nicht schadet. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [TimingSingleDosageForTimeOfDay](#timingsingledosagefortimeofday).
-
-Folgende Beispiele lösen eine Warnung aus:
-
-{% include dosage-constraint-TimingSingleDosageForTimeOfDayWarning-examples.md%}
-
-#### TimingSingleDosageForTimeOfDay
-
-**Beschreibung:**  
-In den dgMP-Profilen sind bei täglicher Dosierung mit ausschließlich `timeOfDay` mehrere Tageszeiten in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
-
-**Warum?**  
-Verhindert unnötige Aufsplitterung gleichartiger Dosierungen und sorgt für eine klare, eindeutige Modellierung der Tageszeiten.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingSingleDosageForTimeOfDay-examples.md%}
-
-#### TimingSingleDosageForWhenWarning
-
-**Beschreibung:**  
-Warnung in `TimingDE`, wenn bei täglicher Dosierung mit ausschließlich `when` mehrere `Dosage`‑Elemente mit identischer Dosis verwendet werden.
-
-**Warum?**  
-Mehrere gleichartige Elemente sind unnötig aufgesplittert und erschweren die Auswertung. Im generischen Profil bleibt es bei einer Warnung, weil die Aufteilung dort nicht schadet. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [TimingSingleDosageForWhen](#timingsingledosageforwhen).
-
-Folgende Beispiele lösen eine Warnung aus:
-
-{% include dosage-constraint-TimingSingleDosageForWhenWarning-examples.md%}
-
-#### TimingSingleDosageForWhen
-
-**Beschreibung:**  
-In den dgMP-Profilen sind bei täglicher Dosierung mit ausschließlich `when` mehrere Zeitabschnitte des Tages in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
-
-**Warum?**  
-Verhindert unnötige Aufsplitterung gleichartiger Dosierungen und sorgt für eine klare, eindeutige Modellierung der Tagesabschnitte.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingSingleDosageForWhen-examples.md%}
-
-#### TimingVarFreqOrPeriod
-
-**Beschreibung:**  
-Bei gleichzeitiger Angabe von Frequenz und Periode sollte entweder nur die Frequenz einschließlich `frequencyMax` oder nur die Periode einschließlich `periodMax` größer als 1 sein.
-
-**Warum?**  
-Die gleichzeitige Variation beider Achsen führt zu einem nur schwer eindeutig interpretierbaren Einnahmeschema.
-
-Folgende Beispiele lösen eine Warnung aus:
-
-{% include dosage-constraint-TimingVarFreqOrPeriod-examples.md%}
-
-#### TimingVarFreqGtMin
-
-**Beschreibung:**  
-Wenn `frequencyMax` verwendet wird, muss der maximale Wert größer als `frequency` sein.
-
-**Warum?**  
-Dadurch wird sichergestellt, dass tatsächlich ein Bereich und kein redundanter oder widersprüchlicher Einzelwert modelliert wird.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingVarFreqGtMin-examples.md%}
-
-#### TimingVarPeriodGtMin
-
-**Beschreibung:**  
-Wenn `periodMax` verwendet wird, muss der maximale Wert größer als `period` sein.
-
-**Warum?**  
-Dadurch wird sichergestellt, dass tatsächlich ein Bereich und kein redundanter oder widersprüchlicher Einzelwert modelliert wird.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-TimingVarPeriodGtMin-examples.md%}
-
-### Dosage-bezogene Constraints
-
-Die folgenden Invarianten beziehen sich auf das Dosage-Element insgesamt (nicht nur auf `timing.repeat`). Sie wirken über alle Dosierungsinstanzen einer Ressource (z. B. alle `dosageInstruction` eines `MedicationRequest`).
-
-#### DosageStructuredOrFreeText / DosageStructuredOrFreeTextWarning
-
-**Beschreibung:**  
-Eine Dosierungsangabe darf entweder vollständig strukturiert (mit `timing` und/oder `doseAndRate`) oder ausschließlich als Freitext (`text`) vorliegen - eine Mischung ist nicht zulässig.
-
-**Hinweis zur Ausprägung:**  
-Im generischen Profil `DosageDE` ist dies als Warnung (`warning`) modelliert (`DosageStructuredOrFreeTextWarning`), im dgMP‑Spezialprofil (`DosageDgMP`) als Fehler (`error`, Invariante `DosageStructuredOrFreeText`). Implementierungen sollten die strukturierte Variante bevorzugen und Freitext nur verwenden, wenn eine strukturierte Abbildung nicht möglich ist.
-
-**Warum?**  
-Verhindert widersprüchliche oder doppelte Informationsquellen (Freitext vs. Struktur) und erleichtert automatische Verarbeitung (z. B. Generierung patientenverständlicher Texte).
-
-Beispiele (Fehlerfall – Mischform aus Text und Struktur):
-
-{% include dosage-constraint-DosageStructuredOrFreeText-examples.md%}
-
-Gültige Varianten (Warnungskontext – nur Text oder nur Struktur):
 
 {% include dosage-constraint-DosageStructuredOrFreeTextWarning-examples.md%}
 
-#### DosageStructuredRequiresBothWarning
+##### DosageStructuredRequiresBothWarning
 
 **Beschreibung:**  
 Warnung in `DosageDE`, wenn bei einer strukturierten Dosierung nur zeitliche Angaben (`timing`) oder nur die Dosis (`doseAndRate`) vorhanden sind. Für reine Bedarfsdosierungen ist `doseAndRate` ohne `timing` zulässig und löst keine Warnung aus.
@@ -291,66 +32,7 @@ Folgende Beispiele lösen eine Warnung aus:
 
 {% include dosage-constraint-DosageStructuredRequiresBothWarning-examples.md%}
 
-#### DosageStructuredRequiresBoth
-
-**Beschreibung:**  
-Wenn in den dgMP-Profilen eine strukturierte Dosierung angegeben wird, müssen sowohl zeitliche Angaben (`timing`) als auch die Dosis (`doseAndRate`) vorhanden sein. Für reine Bedarfsdosierungen darf `doseAndRate` auch ohne `timing` angegeben werden.
-
-**Warum?**  
-Der dgMP setzt auf durchgängig maschinell auswertbare Dosierungen; die Textgenerierung benötigt Zeit und Menge gemeinsam. Eine Dosierung, deren Menge erst außerhalb der Ressource festgelegt wird, ist im dgMP als Freitext-Dosierung abzubilden.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-DosageStructuredRequiresBoth-examples.md%}
-
-#### DosageStructuredRequiresGeneratedText
-
-**Beschreibung:**  
-Liegt eine strukturierte Dosierung vor (strukturierte Elemente befüllt, Freitext leer), muss die Extension `GeneratedDosageInstructionsMeta` existieren sowie genau eine der FHIR R5 RenderedDosageInstruction-Extensions passend zur Ressource (MedicationRequest/Dispense/Statement).
-
-**Warum?**  
-Dokumentiert, dass ein (maschinen-)generierter, patientenlesbarer Dosierungstext verfügbar ist und stellt die Nachvollziehbarkeit der Generierung sicher.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-DosageStructuredRequiresGeneratedText-examples.md%}
-
-#### DosageExtensionsRequireDosage
-
-**Beschreibung:**
-Wenn auf einer MedicationRequest, MedicationDispense oder MedicationStatement die Extension `GeneratedDosageInstructionsMeta` oder die für die jeweilige Ressource passende Extension `renderedDosageInstruction` vorliegt, muss die Ressource mindestens eine Dosierung enthalten (`dosageInstruction` bzw. `dosage`).
-
-**Warum?**
-Die Dosierungs-Extensions enthalten Metadaten beziehungsweise den gerenderten Text zu einer Dosierungsangabe. Ohne Dosierung fehlt ihr fachlicher Bezug. Da es in diesem Fall kein `Dosage`-Objekt gibt, ist die Anforderung als Constraint an den jeweiligen Elternressourcen modelliert.
-
-**Hinweis zur Implementierung:**
-Diese Invariante ist nicht auf den Dosage-Profilen definiert, sondern auf den abstrakten Profilen `MedicationRequestDgMP`, `MedicationDispenseDgMP` und `MedicationStatementDgMP`. Eigene Implementierungsprofile, die nicht von diesen abstrakten dgMP-Profilen ableiten, müssen den jeweils passenden Constraint daher manuell übernehmen.
-
-#### FreeTextMatchesRenderedText
-
-**Beschreibung:**  
-Wenn eine Dosierung als reiner Freitext angegeben ist (nur `text`, kein `timing`/`doseAndRate`), muss der Wert in `dosageInstruction.text` exakt mit dem Wert in der Extension `renderedDosageInstruction` übereinstimmen.
-
-**Warum?**  
-Verhindert Inkonsistenzen zwischen der Freitextangabe und der gerenderten Dosierungsanweisung. Dies stellt sicher, dass der vom Anwender eingegebene Freitext konsistent in der Extension für die Darstellung übernommen wird.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-FreeTextMatchesRenderedText-examples.md%}
-
-#### FreeTextSingleDosageOnly
-
-**Beschreibung:**  
-Wenn eine Dosierung als reiner Freitext angegeben ist (nur `text`, kein `timing`/`doseAndRate`), darf in der Ressource insgesamt nur genau ein `Dosage`‑Eintrag vorkommen.
-
-**Warum?**  
-Verhindert widersprüchliche oder doppelte Freitextangaben, die nicht automatisch zusammengeführt werden können. Fördert eindeutige, konsolidierte Freitext‑Anweisungen, wenn keine strukturierte Modellierung erfolgt.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-FreeTextSingleDosageOnly-examples.md%}
-
-#### FreeTextSingleDosageOnlyWarning
+##### FreeTextSingleDosageOnlyWarning
 
 **Beschreibung:**  
 Wird eine Dosierung als reiner Freitext angegeben, soll nur genau ein `Dosage`‑Element existieren.
@@ -362,7 +44,7 @@ Beispiele (Warnungskontext – mehrere Freitext‑Dosierungen):
 
 {% include dosage-constraint-FreeTextSingleDosageOnlyWarning-examples.md%}
 
-#### DosageDoseUnitSameCodeWarning
+##### DosageDoseUnitSameCodeWarning
 
 **Beschreibung:**  
 Warnung in `DosageDE`, wenn die Dosierungsinstanzen innerhalb derselben Ressource unterschiedliche Dosiereinheiten (Codes) verwenden.
@@ -374,91 +56,7 @@ Folgende Beispiele lösen eine Warnung aus:
 
 {% include dosage-constraint-DosageDoseUnitSameCodeWarning-examples.md%}
 
-#### DosageDoseUnitSameCode
-
-**Beschreibung:**  
-In den dgMP-Profilen müssen alle Dosierungsinstanzen innerhalb derselben Ressource dieselbe Dosiereinheit (Code) verwenden.
-
-**Warum?**  
-Die Textgenerierung übernimmt die gemeinsame Dosis-Einheit aus der ersten auswertbaren Dosis; unterschiedliche Einheiten würden im erzeugten Text stillschweigend verlorengehen. Zudem setzt der dgMP auf durchgängig maschinell vergleichbare Dosierungen.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-DosageDoseUnitSameCode-examples.md%}
-
-#### DosageDoseValueDecimalNotation
-
-**Beschreibung:**  
-Dosiswerte in `doseQuantity.value` sowie `doseRange.low.value` und `doseRange.high.value` müssen in einfacher Dezimalschreibweise mit maximal zwei Nachkommastellen angegeben werden (z. B. `0.5`, `1`, `2.25`). Die vom Datentyp `decimal` erlaubte Exponentialschreibweise ist unzulässig; `0.5` darf also nicht als `50e-2` übermittelt werden.
-
-**Warum?**  
-Der Constraint `DosageDoseQuantityAllowedFractions` schränkt den Wertebereich ein, arbeitet dafür aber auf dem geparsten Zahlenwert und ist gegenüber der Notation blind. Da Dosiswerte in der Praxis auch textnah weiterverarbeitet und angezeigt werden, legt dieser Constraint zusätzlich die Schreibweise fest und hält sie an der BMP-Spezifikation ausgerichtet.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-DosageDoseValueDecimalNotation-examples.md%}
-
-#### DoseRangeHighRequiredWhenLowPresent
-
-**Beschreibung:**  
-Wenn bei `doseRange` eine Untergrenze (`low`) angegeben wird, muss auch eine Obergrenze (`high`) vorhanden sein.
-
-**Warum?**  
-Die Modellierung einer variablen Einzeldosis soll stets einen tatsächlich interpretierbaren Bereich ergeben und keine einseitige Untergrenze.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-DoseRangeHighRequiredWhenLowPresent-examples.md%}
-
-#### DoseRangeLowAndHighSameUnit
-
-**Beschreibung:**  
-Unter- und Obergrenze einer variablen Einzeldosis müssen dieselbe Maßeinheit (`system`, `code`, `unit`) verwenden.
-
-**Warum?**  
-Nur so ist der Bereich fachlich konsistent interpretierbar; gemischte Einheiten würden Mehrdeutigkeiten und Rechenfehler erzeugen.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-DoseRangeLowAndHighSameUnit-examples.md%}
-
-#### DoseRangeNoVarPeriod
-
-**Beschreibung:**  
-Eine variable Einzeldosis (`doseRange`) und eine variable Periode (`periodMax`) sollten nicht gemeinsam verwendet werden.
-
-**Warum?**  
-Die Kombination aus variabler Dosis und variabler Periode ist für Implementierungen und Darstellung nur schwer eindeutig zu verarbeiten. Sie bleibt zulässig, löst aber eine Warnung aus.
-
-Beispiele (Warnungskontext – variable Einzeldosis und variable Periode):
-
-{% include dosage-constraint-DoseRangeNoVarPeriod-examples.md%}
-
-#### VarFreqNoMaxDose
-
-**Beschreibung:**  
-Variable Frequenz (`frequencyMax`) und `maxDosePerPeriod` dürfen nicht gemeinsam verwendet werden.
-
-**Warum?**  
-Beide Angaben begrenzen die Häufigkeit bzw. Gesamtmenge pro Zeitraum. In Kombination entsteht eine doppelte, potenziell widersprüchliche Modellierung.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-VarFreqNoMaxDose-examples.md%}
-
-#### VarPeriodNoMindestabstand
-
-**Beschreibung:**  
-Variable Periode (`periodMax`) und `modifierExtension[MindestabstandZwischenGaben]` dürfen nicht gemeinsam verwendet werden.
-
-**Warum?**  
-Beide Angaben beschreiben Abstände zwischen Gaben. Ihre gleichzeitige Verwendung erzeugt konkurrierende Zeitlogiken.
-
-Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
-
-{% include dosage-constraint-VarPeriodNoMindestabstand-examples.md%}
-
-#### DosageWarnungViererschemaInText
+##### DosageWarnungViererschemaInText
 
 **Beschreibung:**  
 Warnung, wenn ein klassisches 4-Schema (z. B. Darstellung wie "1-0-1-0") irgendwo im Freitext vorkommt, obwohl eine strukturierte Abbildung möglich wäre.
@@ -472,7 +70,459 @@ Gültige Beispiele (Warnungskontext – Freitext enthält 4-Schema):
 
 {% include dosage-constraint-DosageWarnungViererschemaInText-examples.md%}
 
-#### DosageViererschemaInText
+##### TimingSingleDosageForTimeOfDayWarning
+
+**Beschreibung:**  
+Warnung in `TimingDE`, wenn bei täglicher Dosierung mit ausschließlich `timeOfDay` mehrere `Dosage`‑Elemente mit identischer Dosis verwendet werden.
+
+**Warum?**  
+Mehrere gleichartige Elemente sind unnötig aufgesplittert und erschweren die Auswertung. Im generischen Profil bleibt es bei einer Warnung, weil die Aufteilung dort nicht schadet. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [TimingSingleDosageForTimeOfDay](#timingsingledosagefortimeofday).
+
+Folgende Beispiele lösen eine Warnung aus:
+
+{% include dosage-constraint-TimingSingleDosageForTimeOfDayWarning-examples.md%}
+
+##### TimingSingleDosageForWhenWarning
+
+**Beschreibung:**  
+Warnung in `TimingDE`, wenn bei täglicher Dosierung mit ausschließlich `when` mehrere `Dosage`‑Elemente mit identischer Dosis verwendet werden.
+
+**Warum?**  
+Mehrere gleichartige Elemente sind unnötig aufgesplittert und erschweren die Auswertung. Im generischen Profil bleibt es bei einer Warnung, weil die Aufteilung dort nicht schadet. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [TimingSingleDosageForWhen](#timingsingledosageforwhen).
+
+Folgende Beispiele lösen eine Warnung aus:
+
+{% include dosage-constraint-TimingSingleDosageForWhenWarning-examples.md%}
+
+##### TimingBoundsUnitMatchesCodeWarning
+
+**Beschreibung:**  
+Warnung in `TimingDE`, wenn die Einheit (`boundsDuration.unit`) nicht zum UCUM‑Code (`boundsDuration.code`) passt.
+
+**Warum?**  
+Widersprüchliche Angaben wie `code='wk'` mit `unit='Tag(e)'` sind fast immer ein Fehler, die Einheit ist im generischen Profil aber nicht auf die deutschen Bezeichnungen festgelegt. In den dgMP-Profilen gilt für denselben Sachverhalt der Fehler [TimingBoundsUnitMatchesCode](#timingboundsunitmatchescode).
+
+Folgende Beispiele lösen eine Warnung aus:
+
+{% include dosage-constraint-TimingBoundsUnitMatchesCodeWarning-examples.md%}
+
+#### Fehler
+
+##### dos-1
+
+**Beschreibung:**  
+Basisregel aus dem generischen Profil `DosageDE`: Ein Einnahmeanlass (`asNeededFor`) darf nur gesetzt sein, wenn `asNeeded` leer oder `true` ist. Das dgMP‑Profil verschärft dies über `AsNeededForRequiresAsNeeded` auf `asNeeded = true`.
+
+**Warum?**  
+Stellt sicher, dass ein Einnahmeanlass nicht einer Nicht‑Bedarfsdosierung zugeordnet wird.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-dos-1-examples.md%}
+
+### dgMP-Profile
+
+Zusätzlich zu den Regeln der DE-Profile gelten die folgenden Invarianten auf [DosageDgMP](./StructureDefinition-DosageDgMP.html), [TimingDgMP](./StructureDefinition-TimingDgMP.html) und den abstrakten Ressourcenprofilen des dgMP. Sie setzen durchgängig maschinell auswertbare Dosierungen durch, wie sie die [Textgenerierung](./dosierung-textgenerierung.html) voraussetzt.
+
+#### Warnungen
+
+##### DoseRangeNoVarPeriod
+
+**Beschreibung:**  
+Eine variable Einzeldosis (`doseRange`) und eine variable Periode (`periodMax`) sollten nicht gemeinsam verwendet werden.
+
+**Warum?**  
+Die Kombination aus variabler Dosis und variabler Periode ist für Implementierungen und Darstellung nur schwer eindeutig zu verarbeiten. Sie bleibt zulässig, löst aber eine Warnung aus.
+
+Beispiele (Warnungskontext – variable Einzeldosis und variable Periode):
+
+{% include dosage-constraint-DoseRangeNoVarPeriod-examples.md%}
+
+##### TimingVarFreqOrPeriod
+
+**Beschreibung:**  
+Bei gleichzeitiger Angabe von Frequenz und Periode sollte entweder nur die Frequenz einschließlich `frequencyMax` oder nur die Periode einschließlich `periodMax` größer als 1 sein.
+
+**Warum?**  
+Die gleichzeitige Variation beider Achsen führt zu einem nur schwer eindeutig interpretierbaren Einnahmeschema.
+
+Folgende Beispiele lösen eine Warnung aus:
+
+{% include dosage-constraint-TimingVarFreqOrPeriod-examples.md%}
+
+#### Fehler: Timing-bezogen
+
+Die folgenden Invarianten beziehen sich auf `timing.repeat` und wirken über alle Dosierungsinstanzen einer Ressource.
+
+##### TimingFrequencyCount
+
+**Beschreibung:**  
+Wenn die Häufigkeit (`frequency`) angegeben ist, muss sie mit der Anzahl der angegebenen Zeitpunkte (`timeOfDay` oder `when`) übereinstimmen, abhängig davon, welche Felder gesetzt sind.
+
+**Warum?**  
+Diese Regel stellt sicher, dass die Anzahl der Dosierungen pro Periode korrekt mit den angegebenen Zeitpunkten übereinstimmt, wenn `frequency` explizit angegeben wird. So wird verhindert, dass widersprüchliche oder unklare Dosierungsangaben entstehen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingFrequencyCount-examples.md%}
+
+##### TimingPeriodUnit
+
+**Beschreibung:**  
+Wenn `periodUnit` angegeben ist und Wochentage (`dayOfWeek`) angegeben sind, muss die Zeiteinheit (`periodUnit`) „Woche“ (`wk`) sein; andernfalls muss sie „Tag“ (`d`) sein.
+
+**Warum?**  
+Dadurch wird sichergestellt, dass die Zeiteinheit zur Angabe der Dosierungsperiode konsistent zu den verwendeten Feldern passt und keine Missverständnisse bei der Interpretation entstehen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingPeriodUnit-examples.md%}
+
+##### TimingPeriodOnlyWholeNumber
+
+**Beschreibung:**  
+`period` und `periodMax` dürfen nur ganze Zahlen enthalten; Dezimalwerte sind nicht zulässig.
+
+**Warum?**  
+Eine gebrochene Periode (z. B. „alle 1,5 Tage") lässt sich weder eindeutig kommunizieren noch verlässlich in einen Einnahmeplan überführen. Für abweichende Rhythmen ist die nächstkleinere Zeiteinheit zu verwenden.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingPeriodOnlyWholeNumber-examples.md%}
+
+##### TimingOnlyOneType
+
+**Beschreibung:**  
+Es darf pro Dosierung nur eine Art der Zeitangabe verwendet werden (z.B. ausschließlich `4-Schema`, `TimeOfDay`, `DayOfWeek`, `Interval`, Kombinationen wie `DayOfWeek+TimeOfDay` oder `Interval+TimeOfDay`).
+
+**Warum?**  
+Diese Einschränkung verhindert Mehrdeutigkeiten und sorgt dafür, dass die Dosierungszeitpunkte eindeutig interpretierbar bleiben.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOneType-examples.md%}
+
+##### TimingOnlyOneWhen
+
+**Beschreibung:**  
+Es darf nicht derselbe Zeitraum des Tages (`when`) in mehreren Dosierungsinstanzen vorkommen.
+
+**Warum?**  
+Dadurch wird verhindert, dass Dosierungen mehrfach für denselben Zeitraum angegeben werden, was zu Überdosierung oder Verwirrung führen könnte.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOneWhen-examples.md%}
+
+##### TimingOnlyWhenOrTimeOfDay
+
+**Beschreibung:**  
+Es darf nicht die Tageszeit `timeOfDay` und der Zeitraum des Tages `when` in mehreren Dosierungsinstanzen gleichzeitig vorkommen.
+
+**Warum?**  
+Dadurch wird verhindert, dass Dosierungen gemischte Schemata anzeigen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyWhenOrTimeOfDay-examples.md%}
+
+##### TimingOnlyOneTimeOfDay
+
+**Beschreibung:**  
+Es darf nicht dieselbe Tageszeit (`timeOfDay`) in mehreren Dosierungsinstanzen vorkommen.
+
+**Warum?**  
+Auch hier wird sichergestellt, dass Dosierungen nicht mehrfach für dieselbe Uhrzeit definiert werden, um Redundanzen und Fehler zu vermeiden.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOneTimeOfDay-examples.md%}
+
+##### TimingOnlyOneDayOfWeek
+
+**Beschreibung:**  
+Es darf nicht derselbe Wochentag (`dayOfWeek`) in mehreren Dosierungsinstanzen vorkommen.
+
+**Warum?**  
+Dies verhindert doppelte Einträge für denselben Wochentag und stellt eine eindeutige Zuordnung sicher.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOneDayOfWeek-examples.md%}
+
+##### TimingOnlyOneBounds
+
+**Beschreibung:**  
+Für den Zeitrahmen dürfen pro Ressource nur ein Wert und ein Code beziehungsweise ein Start- und ein Endzeitpunkt vorkommen — sowohl für die Dauer (`bounds` vom Typ `Duration`) als auch für Start/Ende (`bounds` vom Typ `Period`).
+
+**Warum?**  
+So wird ausgeschlossen, dass mehrere unterschiedliche Zeiträume für eine Dosierung angegeben werden, was die Interpretation erschweren würde. Die Textgenerierung liest den Zeitrahmen ausschließlich aus dem ersten `Dosage`-Element; ein abweichender Zeitrahmen in einem weiteren Element entfiele im erzeugten Text unbemerkt.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOneBounds-examples.md%}
+
+##### TimingBoundsDurationOnlyWholeNumber
+
+**Beschreibung:**  
+Der Wert der Gesamtdauer (`boundsDuration.value`) darf nur Ganzzahlen enthalten, Nachkommastellen sind nicht zulässig.
+
+**Warum?**  
+Verhindert unklare oder technisch nicht sinnvolle Angaben einer Behandlungsdauer mit Bruchteilen von Zeiteinheiten (z. B. „1,5 Tage“) und sorgt für konsistente, eindeutig interpretierbare Zeiträume.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingBoundsDurationOnlyWholeNumber-examples.md%}
+
+##### TimingBoundsUnitMatchesCode
+
+**Beschreibung:**  
+In den dgMP-Profilen muss die Einheit (`boundsDuration.unit`) zum UCUM‑Code (`boundsDuration.code`) passen; z. B. `wk` nur mit „Woche(n)“, `d` nur mit „Tag(e)“, `mo` nur mit „Monat(e)“, `a` nur mit „Jahr(e)“.
+
+**Warum?**  
+Die Textgenerierung leitet die Zeiteinheit aus dem Code ab; eine abweichende `unit` würde eine Dauer anzeigen, die nicht der übermittelten entspricht.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingBoundsUnitMatchesCode-examples.md%}
+
+##### TimingIntervalOnlyOneFrequency
+
+**Beschreibung:**  
+Bei Intervallangaben darf es nur eine Dosierungsinstanz geben.
+
+**Warum?**  
+Dadurch wird verhindert, dass ein Intervall mehrfach beschrieben wird, was zu widersprüchlichen Angaben führen könnte.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingIntervalOnlyOneFrequency-examples.md%}
+
+##### TimingOnlyOnePeriodForDayOfWeek
+
+**Beschreibung:**  
+Wenn für einen Wochentag mehrere Einträge existieren, müssen sich deren Zeitangaben (`when`/`timeOfDay`) unterscheiden.
+
+**Warum?**  
+Dies stellt sicher, dass für jeden Wochentag die Dosierungszeitpunkte eindeutig sind und keine Dopplungen auftreten.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOnePeriodForDayOfWeek-examples.md%}
+
+##### TimingOnlyOneTimeForInterval
+
+**Beschreibung:**  
+Bei Intervallangaben mit Zeitpunkten (`when` oder `timeOfDay`) dürfen die Zeitangaben nicht mehrfach vorkommen und die Periodenangaben müssen eindeutig sein.
+
+**Warum?**  
+Damit wird verhindert, dass für ein Intervall mehrere widersprüchliche Zeitpunkte oder Perioden definiert werden.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingOnlyOneTimeForInterval-examples.md%}
+
+##### TimingSingleDosageForTimeOfDay
+
+**Beschreibung:**  
+In den dgMP-Profilen sind bei täglicher Dosierung mit ausschließlich `timeOfDay` mehrere Tageszeiten in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
+
+**Warum?**  
+Verhindert unnötige Aufsplitterung gleichartiger Dosierungen und sorgt für eine klare, eindeutige Modellierung der Tageszeiten.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingSingleDosageForTimeOfDay-examples.md%}
+
+##### TimingSingleDosageForWhen
+
+**Beschreibung:**  
+In den dgMP-Profilen sind bei täglicher Dosierung mit ausschließlich `when` mehrere Zeitabschnitte des Tages in einem einzigen `Dosage`‑Element zu modellieren. Mehrere `Dosage`‑Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet.
+
+**Warum?**  
+Verhindert unnötige Aufsplitterung gleichartiger Dosierungen und sorgt für eine klare, eindeutige Modellierung der Tagesabschnitte.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingSingleDosageForWhen-examples.md%}
+
+##### TimingVarFreqGtMin
+
+**Beschreibung:**  
+Wenn `frequencyMax` verwendet wird, muss der maximale Wert größer als `frequency` sein.
+
+**Warum?**  
+Dadurch wird sichergestellt, dass tatsächlich ein Bereich und kein redundanter oder widersprüchlicher Einzelwert modelliert wird.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingVarFreqGtMin-examples.md%}
+
+##### TimingVarPeriodGtMin
+
+**Beschreibung:**  
+Wenn `periodMax` verwendet wird, muss der maximale Wert größer als `period` sein.
+
+**Warum?**  
+Dadurch wird sichergestellt, dass tatsächlich ein Bereich und kein redundanter oder widersprüchlicher Einzelwert modelliert wird.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-TimingVarPeriodGtMin-examples.md%}
+
+
+
+Die folgenden Invarianten beziehen sich auf das Dosage-Element insgesamt (nicht nur auf `timing.repeat`). Sie wirken über alle Dosierungsinstanzen einer Ressource (z. B. alle `dosageInstruction` eines `MedicationRequest`).
+
+#### Fehler: Dosage-bezogen
+
+Die folgenden Invarianten beziehen sich auf das Dosage-Element insgesamt (nicht nur auf `timing.repeat`). Sie wirken über alle Dosierungsinstanzen einer Ressource (z. B. alle `dosageInstruction` eines `MedicationRequest`).
+
+##### DosageStructuredOrFreeText
+
+**Beschreibung:**  
+In den dgMP-Profilen darf eine Dosierungsangabe entweder vollständig strukturiert (mit `timing` und/oder `doseAndRate`) oder ausschließlich als Freitext (`text`) vorliegen - eine Mischung ist nicht zulässig.
+
+**Warum?**  
+Verhindert widersprüchliche oder doppelte Informationsquellen (Freitext vs. Struktur) und erleichtert automatische Verarbeitung (z. B. Generierung patientenverständlicher Texte).
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageStructuredOrFreeText-examples.md%}
+
+##### DosageStructuredRequiresBoth
+
+**Beschreibung:**  
+Wenn in den dgMP-Profilen eine strukturierte Dosierung angegeben wird, müssen sowohl zeitliche Angaben (`timing`) als auch die Dosis (`doseAndRate`) vorhanden sein. Für reine Bedarfsdosierungen darf `doseAndRate` auch ohne `timing` angegeben werden.
+
+**Warum?**  
+Der dgMP setzt auf durchgängig maschinell auswertbare Dosierungen; die Textgenerierung benötigt Zeit und Menge gemeinsam. Eine Dosierung, deren Menge erst außerhalb der Ressource festgelegt wird, ist im dgMP als Freitext-Dosierung abzubilden.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageStructuredRequiresBoth-examples.md%}
+
+##### DosageStructuredRequiresGeneratedText
+
+**Beschreibung:**  
+Liegt eine strukturierte Dosierung vor, muss die Extension `GeneratedDosageInstructionsMeta` existieren sowie genau eine der FHIR R5 RenderedDosageInstruction-Extensions passend zur Ressource (MedicationRequest/Dispense/Statement). Als strukturiert gilt eine Dosierung, bei der `doseAndRate` befüllt und `text` leer ist und die entweder ein `timing` trägt **oder** eine reine Bedarfsdosierung (`asNeededBoolean = true`) ist.
+
+**Warum?**  
+Dokumentiert, dass ein (maschinen-)generierter, patientenlesbarer Dosierungstext verfügbar ist und stellt die Nachvollziehbarkeit der Generierung sicher. Die reine Bedarfsdosierung ist ausdrücklich eingeschlossen: Sie kommt gemäß [DosageStructuredRequiresBoth](#dosagestructuredrequiresboth) ohne `timing` aus, ist aber ebenso renderbar wie jede andere strukturierte Dosierung — eine Anknüpfung allein an `timing` würde sie unbeabsichtigt von der Pflicht ausnehmen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageStructuredRequiresGeneratedText-examples.md%}
+
+##### FreeTextMatchesRenderedText
+
+**Beschreibung:**  
+Wenn eine Dosierung als reiner Freitext angegeben ist (nur `text`, kein `timing`/`doseAndRate`), muss der Wert in `dosageInstruction.text` exakt mit dem Wert in der Extension `renderedDosageInstruction` übereinstimmen.
+
+**Warum?**  
+Verhindert Inkonsistenzen zwischen der Freitextangabe und der gerenderten Dosierungsanweisung. Dies stellt sicher, dass der vom Anwender eingegebene Freitext konsistent in der Extension für die Darstellung übernommen wird.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-FreeTextMatchesRenderedText-examples.md%}
+
+##### FreeTextSingleDosageOnly
+
+**Beschreibung:**  
+Wenn eine Dosierung als reiner Freitext angegeben ist (nur `text`, kein `timing`/`doseAndRate`), darf in der Ressource insgesamt nur genau ein `Dosage`‑Eintrag vorkommen.
+
+**Warum?**  
+Verhindert widersprüchliche oder doppelte Freitextangaben, die nicht automatisch zusammengeführt werden können. Fördert eindeutige, konsolidierte Freitext‑Anweisungen, wenn keine strukturierte Modellierung erfolgt.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-FreeTextSingleDosageOnly-examples.md%}
+
+##### DosageDoseUnitSameCode
+
+**Beschreibung:**  
+In den dgMP-Profilen müssen alle Dosierungsinstanzen innerhalb derselben Ressource dieselbe Dosiereinheit (Code) verwenden.
+
+**Warum?**  
+Die Textgenerierung übernimmt die gemeinsame Dosis-Einheit aus der ersten auswertbaren Dosis; unterschiedliche Einheiten würden im erzeugten Text stillschweigend verlorengehen. Zudem setzt der dgMP auf durchgängig maschinell vergleichbare Dosierungen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageDoseUnitSameCode-examples.md%}
+
+##### DosageDoseQuantityAllowedFractions
+
+**Beschreibung:**  
+Dosiswerte in `doseQuantity` und `doseRange` dürfen nur ganzzahlig sein oder einen der Dezimalanteile `.25`, `.33`, `.5`, `.66` oder `.75` verwenden.
+
+**Warum?**  
+Bildet die in der Praxis teilbaren Darreichungsformen ab (halbe, viertel oder drittel Einheiten) und verhindert Dosiswerte, die sich nicht verabreichen lassen. Die zulässige Schreibweise des Werts regelt zusätzlich [DosageDoseValueDecimalNotation](#dosagedosevaluedecimalnotation).
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageDoseQuantityAllowedFractions-examples.md%}
+
+##### DosageDoseValueDecimalNotation
+
+**Beschreibung:**  
+Dosiswerte in `doseQuantity.value` sowie `doseRange.low.value` und `doseRange.high.value` müssen in einfacher Dezimalschreibweise mit maximal zwei Nachkommastellen angegeben werden (z. B. `0.5`, `1`, `2.25`). Die vom Datentyp `decimal` erlaubte Exponentialschreibweise ist unzulässig; `0.5` darf also nicht als `50e-2` übermittelt werden.
+
+**Warum?**  
+Der Constraint `DosageDoseQuantityAllowedFractions` schränkt den Wertebereich ein, arbeitet dafür aber auf dem geparsten Zahlenwert und ist gegenüber der Notation blind. Da Dosiswerte in der Praxis auch textnah weiterverarbeitet und angezeigt werden, legt dieser Constraint zusätzlich die Schreibweise fest und hält sie an der BMP-Spezifikation ausgerichtet.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DosageDoseValueDecimalNotation-examples.md%}
+
+##### DoseRangeHighRequiredWhenLowPresent
+
+**Beschreibung:**  
+Wenn bei `doseRange` eine Untergrenze (`low`) angegeben wird, muss auch eine Obergrenze (`high`) vorhanden sein.
+
+**Warum?**  
+Die Modellierung einer variablen Einzeldosis soll stets einen tatsächlich interpretierbaren Bereich ergeben und keine einseitige Untergrenze.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DoseRangeHighRequiredWhenLowPresent-examples.md%}
+
+##### DoseRangeLowAndHighSameUnit
+
+**Beschreibung:**  
+Unter- und Obergrenze einer variablen Einzeldosis müssen dieselbe Maßeinheit (`system`, `code`, `unit`) verwenden.
+
+**Warum?**  
+Nur so ist der Bereich fachlich konsistent interpretierbar; gemischte Einheiten würden Mehrdeutigkeiten und Rechenfehler erzeugen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-DoseRangeLowAndHighSameUnit-examples.md%}
+
+##### VarFreqNoMaxDose
+
+**Beschreibung:**  
+Variable Frequenz (`frequencyMax`) und `maxDosePerPeriod` dürfen nicht gemeinsam verwendet werden.
+
+**Warum?**  
+Beide Angaben begrenzen die Häufigkeit bzw. Gesamtmenge pro Zeitraum. In Kombination entsteht eine doppelte, potenziell widersprüchliche Modellierung.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-VarFreqNoMaxDose-examples.md%}
+
+##### VarPeriodNoMindestabstand
+
+**Beschreibung:**  
+Variable Periode (`periodMax`) und `modifierExtension[MindestabstandZwischenGaben]` dürfen nicht gemeinsam verwendet werden.
+
+**Warum?**  
+Beide Angaben beschreiben Abstände zwischen Gaben. Ihre gleichzeitige Verwendung erzeugt konkurrierende Zeitlogiken.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-VarPeriodNoMindestabstand-examples.md%}
+
+##### DosageViererschemaInText
 
 **Beschreibung:**  
 `Dosage.text` darf nicht ausschließlich aus einem 4-Schema bestehen. Erfasst wird der reine Fall – vier durch `-` oder `–` getrennte Werte, optional mit Nachkommastellen, Bruchangabe und nachgestellter Einheit (z. B. `1-0-1-0`, `0,5-0-0,5-0`, `1-0-1-0 Stück`). Ein 4-Schema, das in einen Text eingebettet ist, löst weiterhin nur die Warnung `DosageWarnungViererschemaInText` aus.
@@ -484,7 +534,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-DosageViererschemaInText-examples.md%}
 
-#### PatientInstructionIdentical
+##### PatientInstructionIdentical
 
 **Beschreibung:**  
 Wird `patientInstruction` in einer Ressource mit mehreren Dosierungen verwendet, muss das Feld in allen `Dosage`‑Elementen identisch befüllt sein.
@@ -496,7 +546,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-PatientInstructionIdentical-examples.md%}
 
-#### MaxDoseSameUnitAsDose
+##### MaxDoseSameUnitAsDose
 
 **Beschreibung:**  
 `maxDosePerPeriod` muss dieselbe Einheit, denselben Code und dasselbe System wie `doseQuantity` verwenden.
@@ -508,7 +558,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-MaxDoseSameUnitAsDose-examples.md%}
 
-#### MaxDosePerPeriodOnly24hOr1d
+##### MaxDosePerPeriodOnly24hOr1d
 
 **Beschreibung:**  
 `maxDosePerPeriod` ist nur mit einem Bezugszeitraum von **24 Stunden** (`24 h`) oder **1 Tag** (`1 d`) zulässig. Andere Perioden (z. B. „maximal 3 alle 6 h“) sind nicht erlaubt.
@@ -520,7 +570,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-MaxDosePerPeriodOnly24hOr1d-examples.md%}
 
-#### MaxDoseOnlyWhenAsNeeded
+##### MaxDoseOnlyWhenAsNeeded
 
 **Beschreibung:**  
 Eine Maximalmenge (`maxDosePerPeriod`) darf nur bei einer Bedarfsdosierung (`asNeededBoolean = true`) angegeben werden.
@@ -532,7 +582,19 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-MaxDoseOnlyWhenAsNeeded-examples.md%}
 
-#### AsNeededForRequiresAsNeeded
+##### MaxDosePerPeriodIdentical
+
+**Beschreibung:**  
+Enthält eine Ressource mehrere `Dosage`-Elemente, muss `maxDosePerPeriod` in allen Elementen identisch befüllt sein — in Zähler (Wert und Einheit) wie in Nenner (Wert und Code). Entweder tragen alle Elemente die Angabe oder keines, und jede vorhandene Angabe muss alle vier Teilfelder führen.
+
+**Warum?**  
+Die Maximalmenge gilt für die Gesamtmenge im Bezugszeitraum, nicht je Einzelsegment. Die Textgenerierung liest sie ausschließlich aus dem ersten `Dosage`-Element und stellt sie einmal am Ende der Anweisung dar (siehe [Maximalmenge](./dosierung-textgenerierung.html#maximalmenge-maxdoseperperiod)). Ohne diesen Constraint könnte ein zweites Element eine abweichende Obergrenze führen, die im erzeugten Text unbemerkt entfiele — mit unmittelbarer Auswirkung auf die Arzneimittelsicherheit.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-MaxDosePerPeriodIdentical-examples.md%}
+
+##### AsNeededForRequiresAsNeeded
 
 **Beschreibung:**  
 Ein Einnahmeanlass (`extension[asNeededFor]`) darf nur bei einer Bedarfsdosierung (`asNeededBoolean = true`) angegeben werden. Eine Bedarfsdosierung selbst benötigt keinen Einnahmeanlass.
@@ -544,7 +606,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-AsNeededForRequiresAsNeeded-examples.md%}
 
-#### AsNeededSingleDosageOnly
+##### AsNeededSingleDosageOnly
 
 **Beschreibung:**
 Eine reine Bedarfsdosierung (`asNeededBoolean = true` ohne `timing`) darf nur als einziges `Dosage`-Element der Ressource angegeben werden.
@@ -556,14 +618,65 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 {% include dosage-constraint-AsNeededSingleDosageOnly-examples.md%}
 
-#### dos-1
+##### AsNeededIdentical
 
-**Beschreibung:**  
-Basisregel aus dem generischen Profil `DosageDE`: Ein Einnahmeanlass (`asNeededFor`) darf nur gesetzt sein, wenn `asNeeded` leer oder `true` ist. Das dgMP‑Profil verschärft dies über `AsNeededForRequiresAsNeeded` auf `asNeeded = true`.
+**Beschreibung:**
+Enthält eine Ressource mehrere `Dosage`-Elemente, muss das Bedarfskennzeichen (`asNeededBoolean`) in allen Elementen identisch befüllt sein. Entweder tragen alle Elemente die Angabe oder keines.
 
-**Warum?**  
-Stellt sicher, dass ein Einnahmeanlass nicht einer Nicht‑Bedarfsdosierung zugeordnet wird.
+**Warum?**
+Die Bedarfskennzeichnung gilt für die Dosierung als Ganzes und entscheidet über die gesamte Textform: Sie erzeugt das vorangestellte „Bei …“, schaltet Mindestabstand und Maximalmenge frei und bewirkt die Großschreibung am Zeilenanfang. Die Textgenerierung liest sie ausschließlich aus dem ersten `Dosage`-Element. Wäre nur ein späteres Element als Bedarf gekennzeichnet, entfiele die Kennzeichnung vollständig und eine Bedarfsmedikation erschiene als festes Einnahmeschema.
 
 Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
-{% include dosage-constraint-dos-1-examples.md%}
+{% include dosage-constraint-AsNeededIdentical-examples.md%}
+
+##### AsNeededForIdentical
+
+**Beschreibung:**
+Enthält eine Ressource mehrere `Dosage`-Elemente, muss der Einnahmeanlass (`extension[asNeededFor]`) in allen Elementen übereinstimmen. Mehrere Anlässe je Element sind zulässig, müssen dann aber in jedem Element dieselben sein; auf die Reihenfolge kommt es nicht an.
+
+**Warum?**
+Der Einnahmeanlass wird ausschließlich aus dem ersten `Dosage`-Element gelesen und dem Text vorangestellt (siehe [Einnahmeanlass](./dosierung-textgenerierung.html#einnahmeanlass-asneededfor)). Ein nur in einem späteren Element angegebener oder dort abweichender Anlass würde im erzeugten Text ersatzlos entfallen und die Dosierung auf ein generisches „Bei Bedarf“ reduzieren.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-AsNeededForIdentical-examples.md%}
+
+##### MindestabstandIdentical
+
+**Beschreibung:**
+Enthält eine Ressource mehrere `Dosage`-Elemente, muss der Mindestabstand zwischen Gaben (`modifierExtension[mindestabstandZwischenGaben]`) in allen Elementen identisch befüllt sein — in Wert wie in Zeiteinheit. Entweder tragen alle Elemente die Angabe oder keines, und jede vorhandene Angabe muss vollständig sein (`valueDuration.value` **und** `valueDuration.code`).
+
+**Warum?**
+Der Mindestabstand wird ausschließlich aus dem ersten `Dosage`-Element gelesen. Da es sich um eine `modifierExtension` handelt, verändert er die zulässige Anwendung der Dosierung; ein nur in einem späteren Element hinterlegter Abstand entfiele im erzeugten Text unbemerkt.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-MindestabstandIdentical-examples.md%}
+
+##### MindestabstandUnitMatchesCode
+
+**Beschreibung:**
+Die Anzeigeeinheit des Mindestabstands (`valueDuration.unit`) muss zum UCUM-Code passen: `min` nur mit „Minute(n)“, „Minute“ oder „Minuten“, `h` nur mit „Stunde(n)“, „Stunde“ oder „Stunden“. Als Code sind ausschließlich `min` und `h` zulässig (ValueSet `MindestabstandUnitsOfTimeDgMPVS`).
+
+**Warum?**
+Die Textgenerierung leitet die ausgeschriebene Einheit aus `.code` ab. Ohne diesen Constraint könnte eine profilvalide Ressource `code = 'h'` mit `unit = 'Tag(e)'` führen — der erzeugte Text spräche dann von Stunden, während die Ressource Tage anzeigt. Der Constraint entspricht [TimingBoundsUnitMatchesCode](#timingboundsunitmatchescode) für den Zeitrahmen.
+
+Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
+
+{% include dosage-constraint-MindestabstandUnitMatchesCode-examples.md%}
+
+#### Fehler: Auf Ressourcen-Ebene
+
+Die folgende Invariante ist an den Elternressourcen modelliert, weil sie einen Fall abdeckt, in dem gar kein `Dosage`-Objekt vorliegt. Sie existiert je einmal für `MedicationRequest`, `MedicationDispense` und `MedicationStatement` (Constraint-Keys `ExtRequiresDosage-MR-01`, `-MD-01` und `-MS-01`).
+
+##### DosageExtensionsRequireDosage
+
+**Beschreibung:**
+Wenn auf einer MedicationRequest, MedicationDispense oder MedicationStatement die Extension `GeneratedDosageInstructionsMeta` oder die für die jeweilige Ressource passende Extension `renderedDosageInstruction` vorliegt, muss die Ressource mindestens eine Dosierung enthalten (`dosageInstruction` bzw. `dosage`).
+
+**Warum?**
+Die Dosierungs-Extensions enthalten Metadaten beziehungsweise den gerenderten Text zu einer Dosierungsangabe. Ohne Dosierung fehlt ihr fachlicher Bezug. Da es in diesem Fall kein `Dosage`-Objekt gibt, ist die Anforderung als Constraint an den jeweiligen Elternressourcen modelliert.
+
+**Hinweis zur Implementierung:**
+Diese Invariante ist nicht auf den Dosage-Profilen definiert, sondern auf den abstrakten Profilen `MedicationRequestDgMP`, `MedicationDispenseDgMP` und `MedicationStatementDgMP`. Eigene Implementierungsprofile, die nicht von diesen abstrakten dgMP-Profilen ableiten, müssen den jeweils passenden Constraint daher manuell übernehmen.

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -153,7 +153,9 @@ Die Tabelle ist **abschließend** und deckt die required gebundene FHIR-Codelist
 
 Uhrzeiten werden anhand ihres Eingabestrings aufsteigend sortiert und im Format `HH:MM Uhr` ausgegeben (z. B. `08:00 Uhr`). Akzeptiert werden nullaufgefüllte Werte im Format `HH:MM` oder `HH:MM:SS` mit optionalen Sekundenbruchteilen. Stunde und Minute werden übernommen, Sekunden und Sekundenbruchteile entfallen. Ein nicht parsebarer oder außerhalb des zulässigen Uhrzeitbereichs liegender Wert führt zum Abbruch.
 
-Mehrere Uhrzeiten innerhalb **desselben** `Dosage`-Elements werden vor dem Gedankenstrich mit Komma zusammengefasst und teilen sich dessen Dosis, z. B. `08:00 Uhr, 20:00 Uhr — je 1 Stück`. Uhrzeitgruppen aus verschiedenen `Dosage`-Elementen werden anhand ihrer jeweils frühesten Uhrzeit sortiert und anschließend ebenfalls mit Komma verbunden.
+Alle Uhrzeiten werden über **sämtliche** `Dosage`-Elemente hinweg eingesammelt und gemeinsam aufsteigend sortiert. Die Reihenfolge der `Dosage`-Elemente in der Ressource hat damit keinen Einfluss auf die Reihenfolge der Uhrzeiten im Text.
+
+Unmittelbar aufeinanderfolgende Uhrzeiten mit **derselben** Dosis werden anschließend vor einem gemeinsamen Gedankenstrich mit Komma zusammengefasst, z. B. `08:00 Uhr, 20:00 Uhr — je 1 Stück`. Liegt eine Uhrzeit mit abweichender Dosis dazwischen, entsteht für jede Uhrzeit ein eigenes Segment; die aufsteigende Sortierung hat Vorrang vor der Zusammenfassung.
 
 *Beispiel:* Das erste `Dosage`-Element enthält `timeOfDay = [08:00:00, 12:00:00]` und eine Dosis von `1 Stück`; das zweite enthält `timeOfDay = [20:00:00]` und eine Dosis von `2 Stück`. Das Ergebnis lautet:
 
@@ -344,9 +346,9 @@ Die Werte werden über alle `Dosage`-Elemente eingesammelt. Für jedes Element w
 [{Zeitrahmen} ]täglich: {Zeitgruppe} — je {Dosis}[, {Zeitgruppe2} — je {Dosis2} …][. Hinweis: {Instruktionen}]
 ```
 
-Eine `{Zeitgruppe}` enthält alle aufsteigend sortierten `timeOfDay`-Werte **eines** `Dosage`-Elements, mit Komma getrennt. Die Gruppe wird über einen Gedankenstrich mit der Dosis dieses Elements verbunden. Mehrere Gruppen werden anhand ihrer jeweils frühesten Uhrzeit sortiert und mit Komma getrennt. Der Marker lautet in diesem Schema immer `täglich`; vorhandene Frequenzwerte werden hier nicht zusätzlich ausgegeben.
+Alle `timeOfDay`-Werte werden über sämtliche `Dosage`-Elemente hinweg gemeinsam aufsteigend sortiert. Eine `{Zeitgruppe}` fasst dabei die unmittelbar aufeinanderfolgenden Uhrzeiten zusammen, die sich dieselbe Dosis teilen; sie wird über einen Gedankenstrich mit dieser Dosis verbunden. Mehrere Gruppen werden mit Komma getrennt. Der Marker lautet in diesem Schema immer `täglich`; vorhandene Frequenzwerte werden hier nicht zusätzlich ausgegeben.
 
-*Beispiele:* `täglich: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück` · bei zwei Uhrzeiten im selben `Dosage`-Element: `täglich: 08:00 Uhr, 20:00 Uhr — je 1 Stück`
+*Beispiele:* `täglich: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück` · bei zwei Uhrzeiten mit gleicher Dosis: `täglich: 08:00 Uhr, 20:00 Uhr — je 1 Stück` · trennt eine abweichende Dosis die Uhrzeiten, bleibt die Sortierung maßgeblich: `täglich: 01:00 Uhr — je 1 Stück, 18:00 Uhr — je 3 Stück, 23:00 Uhr — je 1 Stück`
 
 ### Schema mit Wochentags-Bezug
 
@@ -385,7 +387,7 @@ Aufbau (mit Uhrzeiten):        [{Zeitrahmen}: ]{Wochentag} {Zeit} — je {Dosis}
 Aufbau (mit Tagesabschnitten): [{Zeitrahmen}: ]{Wochentag} <MORN>-<NOON>-<EVE>-<NIGHT> {Einheit}[; …][. Hinweis: {Instruktionen}]
 ```
 
-Jeder belegte Tag bildet mit seinen Uhrzeiten oder seinem Tagesabschnitts-Muster ein Segment. Mehrere Segmente werden in kanonischer Reihenfolge der Wochentage sortiert und mit Semikolon getrennt; das gilt auch, wenn die Angabe zwischen mehreren oder allen Wochentagen übereinstimmt. Innerhalb eines Tages werden Uhrzeitgruppen anhand ihrer frühesten Uhrzeit sortiert. Mehrere Uhrzeiten desselben `Dosage`-Elements stehen vor einem gemeinsamen Gedankenstrich; Uhrzeitgruppen werden mit Komma getrennt. Tagesabschnitte werden zum Vier-Positionen-Muster zusammengezogen.
+Jeder belegte Tag bildet mit seinen Uhrzeiten oder seinem Tagesabschnitts-Muster ein Segment. Mehrere Segmente werden in kanonischer Reihenfolge der Wochentage sortiert und mit Semikolon getrennt; das gilt auch, wenn die Angabe zwischen mehreren oder allen Wochentagen übereinstimmt. Innerhalb eines Tages werden alle Uhrzeiten dieses Tages über sämtliche `Dosage`-Elemente hinweg gemeinsam aufsteigend sortiert; unmittelbar aufeinanderfolgende Uhrzeiten mit derselben Dosis stehen vor einem gemeinsamen Gedankenstrich. Uhrzeitgruppen werden mit Komma getrennt. Tagesabschnitte werden zum Vier-Positionen-Muster zusammengezogen.
 
 *Beispiele:*
 

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -1,8 +1,10 @@
 Diese Seite beschreibt die Erzeugung eines menschenlesbaren Dosierungstextes aus einer gesamten Arzneimittel‑Ressource (`MedicationRequest`, `MedicationDispense` oder `MedicationStatement`).
 
-Referenz-Implementierung: [Python Skript](https://github.com/hl7germany/dgMP-DosageTextgenerierung-Skript/blob/main/medication-dosage-to-text.py). Die nachfolgende Beschreibung bildet den Algorithmus des im IG verwendeten Skripts `scripts/medication-dosage-to-text.py` vollständig ab. Das verlinkte Skript kann außerhalb dieses Implementation Guides eigenständig versioniert sein. In den Beispielen ist ersichtlich, welche Version der Referenzimplementierung zum Zeitpunkt der Erstellung genutzt wurde (siehe [Versionierung](#versionierung)).
+**Verbindlich ist der auf dieser Seite beschriebene Algorithmus.** Er ist die normative Festlegung der Textgenerierung; Implementierungen müssen ihn nachbilden, unabhängig von der gewählten Programmiersprache. Die aktuelle Version des Algorithmus ist **2.0.0** (siehe [Versionierung](#versionierung)).
 
-Voraussetzung für eine erfolgreiche Texterzeugung ist stets ein **profilkonformer Input**; im Profil gestrichene Elemente sind nicht Teil der Verarbeitung. Das Skript ist kein Ersatz für die FHIR-Profilvalidierung: Es prüft einige nicht zulässige Konstellationen defensiv, führt aber keine vollständige Invariantenprüfung durch.
+Zur Veranschaulichung steht eine **Beispielimplementierung** als [Python-Skript](https://github.com/hl7germany/dgMP-DosageTextgenerierung-Skript/blob/main/medication-dosage-to-text.py) bereit, mit der auch die Beispieltexte dieses Implementation Guides erzeugt werden. Sie ist weder verbindlich noch vollständig maßgeblich: Weicht sie von dieser Seite ab, gilt diese Seite. Das Skript führt die umgesetzte Algorithmus-Version in `__version__`; sie entspricht der hier angegebenen.
+
+Voraussetzung für eine erfolgreiche Texterzeugung ist stets ein **profilkonformer Input**; im Profil gestrichene Elemente sind nicht Teil der Verarbeitung. Der Algorithmus ist kein Ersatz für die FHIR-Profilvalidierung: Er prüft einige nicht zulässige Konstellationen defensiv, führt aber keine vollständige Invariantenprüfung durch.
 
 Diese Seite stellt zwei Aspekte dar: **Teil A** beschreibt, wie jede einzelne Angabe einer `Dosage` in Text überführt wird. **Teil B** beschreibt, wie diese Bausteine je zulässigem Schema zu einem vollständigen Dosierungstext zusammengesetzt werden.
 
@@ -187,11 +189,11 @@ Es können **mehrere** Einnahmeanlässe angegeben sein (`asNeededFor 0..*`, fach
 
 Details zur Zusammensetzung siehe [Schema für Bedarfsmedikation](#schema-für-bedarfsmedikation).
 
-Ausgewertet werden nur Extensions mit der exakten kanonischen URL aus der [Feldreferenz](#feldreferenz). Von jeder passenden Extension wird ausschließlich `valueCodeableConcept.text` übernommen. Im Profil `DosageDgMP` ist `coding` auf `0..0` eingeschränkt und `.text` verpflichtend. Fehlt dennoch ein nicht leerer Text, bricht die Referenzimplementierung mit einem Fehler ab; die Extension wird nicht stillschweigend ignoriert. Führender und abschließender Leerraum des Textes wird entfernt.
+Ausgewertet werden nur Extensions mit der exakten kanonischen URL aus der [Feldreferenz](#feldreferenz). Von jeder passenden Extension wird ausschließlich `valueCodeableConcept.text` übernommen. Im Profil `DosageDgMP` ist `coding` auf `0..0` eingeschränkt und `.text` verpflichtend. Fehlt dennoch ein nicht leerer Text, bricht der Algorithmus mit einem Fehler ab; die Extension wird nicht stillschweigend ignoriert. Führender und abschließender Leerraum des Textes wird entfernt.
 
 ### Mindestabstand zwischen Gaben
 
-Der Mindestabstand wird nur im Bedarfsfall ausgegeben und lautet `im Abstand von mindestens {Wert} {Zeiteinheit}`. Das Skript durchsucht `modifierExtension` nach der exakten kanonischen URL `MindestabstandZwischenGaben` und verwendet die erste passende Extension. `valueDuration`, `valueDuration.value` und `valueDuration.code` sind verpflichtend — im Profil auf `1..1` gesetzt und zusätzlich vom Algorithmus geprüft; der Wert muss numerisch und größer als `0` sein. Andernfalls bricht der Algorithmus mit einem Fehler ab. Die Formatierung entspricht `boundsDuration`, jedoch ohne das Wort `für`.
+Der Mindestabstand wird nur im Bedarfsfall ausgegeben und lautet `im Abstand von mindestens {Wert} {Zeiteinheit}`. Der Algorithmus durchsucht `modifierExtension` nach der exakten kanonischen URL `MindestabstandZwischenGaben` und verwendet die erste passende Extension. `valueDuration`, `valueDuration.value` und `valueDuration.code` sind verpflichtend — im Profil auf `1..1` gesetzt und zusätzlich vom Algorithmus geprüft; der Wert muss numerisch und größer als `0` sein. Andernfalls bricht der Algorithmus mit einem Fehler ab. Die Formatierung entspricht `boundsDuration`, jedoch ohne das Wort `für`.
 
 Als Zeiteinheit sind **ausschließlich Minuten (`min`) und Stunden (`h`)** zulässig; `valueDuration.code` ist required an `MindestabstandUnitsOfTimeDgMPVS` gebunden, `valueDuration.system` ist auf UCUM festgelegt. Die Anzeigeeinheit `valueDuration.unit` muss zum Code passen (Invariante `MindestabstandUnitMatchesCode`) — der erzeugte Text leitet die Einheit aus `.code` ab, sodass ein abweichendes `.unit` sonst der Ressource widerspräche.
 
@@ -355,7 +357,7 @@ Die Dosis-Einheit stammt aus dem ersten Element mit auswertbarer Dosis. Wird bei
 [{Zeitrahmen} ]{Intervall}: {Zeit oder Abschnitt} — je {Dosis}[, … ][. Hinweis: {Instruktionen}]
 ```
 
-Jede Uhrzeit oder jeder Tagesabschnitt bildet gemeinsam mit seiner Dosis ein Segment. Das gilt auch, wenn die Dosis zwischen mehreren oder allen Segmenten übereinstimmt. Segmente mit Tagesabschnitten werden in der festen Reihenfolge morgens, mittags, abends, zur Nacht sortiert; Segmente mit Uhrzeiten anhand des Eingabestrings aufsteigend. Treten – bei nicht profilkonformem Input über mehrere `Dosage`-Elemente hinweg – beide Arten gemeinsam auf, stehen **alle** Tagesabschnitte vor **allen** Uhrzeiten. Die Segmente werden mit Komma getrennt. Bei mehrfacher Belegung desselben Zeit-Schlüssels verwendet die Referenzimplementierung die Dosis des zuerst durchlaufenen zugehörigen `Dosage`-Elements; profilkonformer Input verhindert diesen Mehrdeutigkeitsfall.
+Jede Uhrzeit oder jeder Tagesabschnitt bildet gemeinsam mit seiner Dosis ein Segment. Das gilt auch, wenn die Dosis zwischen mehreren oder allen Segmenten übereinstimmt. Segmente mit Tagesabschnitten werden in der festen Reihenfolge morgens, mittags, abends, zur Nacht sortiert; Segmente mit Uhrzeiten anhand des Eingabestrings aufsteigend. Treten – bei nicht profilkonformem Input über mehrere `Dosage`-Elemente hinweg – beide Arten gemeinsam auf, stehen **alle** Tagesabschnitte vor **allen** Uhrzeiten. Die Segmente werden mit Komma getrennt. Bei mehrfacher Belegung desselben Zeit-Schlüssels verwendet der Algorithmus die Dosis des zuerst durchlaufenen zugehörigen `Dosage`-Elements; profilkonformer Input verhindert diesen Mehrdeutigkeitsfall.
 
 *Beispiel:* `alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück`
 
@@ -381,7 +383,7 @@ Bei der Kombination mit Tagesabschnitten stammt die gemeinsame Einheit aus dem e
 
 Eine Bedarfsmedikation liegt vor, wenn auf Ebene der `Dosage` `asNeededBoolean = true` gesetzt ist. Sie kann als **reine Bedarfsdosierung** (ohne `timing`) oder als **Kennzeichnung eines strukturierten Dosierschemas** auftreten (siehe [Bedarfsmedikation](./schema-bedarfsmedikation.html)).
 
-Bei einer **reinen Bedarfsdosierung** muss die Ressource genau ein `Dosage`-Element enthalten (Invariante `AsNeededSingleDosageOnly`). Mehrere Dosen ohne zeitliche Zuordnung wären nicht eindeutig zu einem gemeinsamen Text zusammenführbar. Das Skript bricht deshalb auch bei nicht vorab validiertem Input mit mehreren `Dosage`-Elementen ab.
+Bei einer **reinen Bedarfsdosierung** muss die Ressource genau ein `Dosage`-Element enthalten (Invariante `AsNeededSingleDosageOnly`). Mehrere Dosen ohne zeitliche Zuordnung wären nicht eindeutig zu einem gemeinsamen Text zusammenführbar. Der Algorithmus bricht deshalb auch bei nicht vorab validiertem Input mit mehreren `Dosage`-Elementen ab.
 
 ```
 [{Zeitrahmen} ]bei {Einnahmeanlass}: [im Abstand von mindestens {Mindestabstand} ]je {Dosis}[ — nicht mehr als {Maximalmenge}][. Hinweis: {Instruktionen}]
@@ -408,7 +410,7 @@ Bei einer **reinen Bedarfsdosierung** muss die Ressource genau ein `Dosage`-Elem
 
 Enthält die `Dosage` ausschließlich freien Text (`text` vorhanden, `timing` **und** `doseAndRate` leer), wird dieser übernommen. Alle drei Bedingungen gehören zur Erkennungsregel: Stünde neben dem Text eine strukturierte Dosis, müsste der Algorithmus raten, welche der beiden Angaben gilt — deshalb greift dann nicht die Freitext-Regel, sondern die reguläre Schema-Erkennung.
 
-Bei reinem Freitext darf die Ressource **genau ein** `Dosage`-Element enthalten (Invariante `FreeTextSingleDosageOnly`), und `Dosage.text` ist `0..1`; bei profilkonformem Input gibt es also genau **ein** Textfeld. Das Skript entfernt an dessen Anfang und Ende Leerraum. Der verbleibende Inhalt wird ansonsten unverändert ausgegeben.
+Bei reinem Freitext darf die Ressource **genau ein** `Dosage`-Element enthalten (Invariante `FreeTextSingleDosageOnly`), und `Dosage.text` ist `0..1`; bei profilkonformem Input gibt es also genau **ein** Textfeld. Der Algorithmus entfernt an dessen Anfang und Ende Leerraum. Der verbleibende Inhalt wird ansonsten unverändert ausgegeben.
 
 *Beispiel:* `Nach Bedarf bei Schmerzen`
 
@@ -469,7 +471,7 @@ Für eine Übersicht der in diesem IG bereitgestellten Beispiele siehe [Beispiel
 
 ## Fehler und Validierung
 
-Die formale Definition zulässiger Felder und Kombinationen liegt in den Timing- und Dosierungs-Invarianten dieses IG (siehe [Constraints](./dosierung-constraints.html)). Die Referenzimplementierung führt **keine vollständige Validierung** und keine Auflistung unzulässiger Felder durch. Ihr konkretes Fehlerverhalten lautet:
+Die formale Definition zulässiger Felder und Kombinationen liegt in den Timing- und Dosierungs-Invarianten dieses IG (siehe [Constraints](./dosierung-constraints.html)). Der Algorithmus führt **keine vollständige Validierung** und keine Auflistung unzulässiger Felder durch. Sein konkretes Fehlerverhalten lautet:
 
 * nicht unterstützter `resourceType`: Abbruch mit `ValueError("Unsupported resource type: {resourceType}")`
 * nicht klassifizierbare Merkmalskombination: Abbruch mit `ValueError("Die Dosierung entspricht keinem unterstützten Dosierungsschema.")`. Es wird **kein** Ersatztext zurückgegeben — ein solcher würde als generierte Dosieranweisung publiziert und dort eine Aussage vortäuschen, die der Algorithmus nicht treffen kann.
@@ -501,9 +503,9 @@ Andere Profilverletzungen können je nach fehlendem Feld dennoch zu einem unvoll
 
 ## Versionierung
 
-Die Version des Algorithmus ist im Skript hinterlegt (`__version__`) und wird über die Extension [GeneratedDosageInstructionsMeta](./StructureDefinition-GeneratedDosageInstructionsMeta.html) an validierenden Instanzen geführt. So lassen sich Textinhalt und verwendete Algorithmus-Version nachvollziehbar prüfen.
+Die Version des verwendeten Algorithmus MUSS über die Extension [GeneratedDosageInstructionsMeta](./StructureDefinition-GeneratedDosageInstructionsMeta.html) gesetzt werden. So lassen sich Textinhalt und verwendete Algorithmus-Version nachvollziehbar prüfen.
 
-Diese Seite beschreibt den Stand **`1.1.0-beta-8`**.
+Diese Seite beschreibt die Algorithmus-Version **2.0.0**. Die Nummer bezeichnet den hier festgelegten Algorithmus, nicht ein einzelnes Programm: Die Beispielimplementierung führt sie in `__version__` und gibt sie beim Erzeugen der Beispiele in `algorithmVersion` weiter. Eine eigene Implementierung trägt dieselbe Nummer ein, sobald sie diesen Algorithmus umsetzt.
 
 ## Quellen / weiterführende Hinweise
 

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -19,11 +19,12 @@ Die Verarbeitung erfolgt in dieser Reihenfolge:
    * `MedicationDispense.dosageInstruction`
    * `MedicationStatement.dosage`
 2. Bei einem anderen Ressourcentyp wird mit einem Fehler abgebrochen (`Unsupported resource type: {resourceType}`). Ist die gelesene Liste leer oder fehlt sie, ist das Ergebnis ein leerer String.
-3. Enthält die Liste eine reine Bedarfsdosierung (`asNeededBoolean = true` ohne `timing`) und insgesamt nicht genau ein `Dosage`-Element, wird die Verarbeitung abgebrochen.
-4. Das Darstellungsschema wird ausschließlich anhand des **ersten** `Dosage`-Elements und in der unter [Schema-Erkennung](#schema-erkennung) angegebenen Priorität bestimmt.
-5. Der schemaspezifische Generator sammelt die benötigten Dosis-/Zeitsegmente. Je nach Schema werden alle `Dosage`-Elemente oder nur das erste verarbeitet; die genaue Aggregation ist unter [Aggregation mehrerer Dosage-Elemente](#aggregation-mehrerer-dosage-elemente) festgelegt.
-6. Der Generator setzt Zeitrahmen, Bedarfsangaben, Rhythmus und Kerntext zusammen. Danach werden – außer bei Freitext – Maximalmenge und `patientInstruction` ergänzt.
-7. Abschließend wird der Text – außer bei Freitext – normalisiert. Ist das erste `Dosage`-Element als Bedarf gekennzeichnet, wird zusätzlich exakt das erste Zeichen des Ergebnisses in einen Großbuchstaben umgewandelt.
+3. Setzt eines der `Dosage`-Elemente `timeOfDay` **und** `when` gemeinsam, wird abgebrochen. Beides zugleich ist bereits durch die FHIR-Basisinvariante `tim-10` ausgeschlossen; ohne diese Prüfung würde je nach Schema eine der beiden Angaben stillschweigend verworfen.
+4. Enthält die Liste eine reine Bedarfsdosierung (`asNeededBoolean = true` ohne `timing`) und insgesamt nicht genau ein `Dosage`-Element, wird die Verarbeitung abgebrochen.
+5. Das Darstellungsschema wird ausschließlich anhand des **ersten** `Dosage`-Elements und in der unter [Schema-Erkennung](#schema-erkennung) angegebenen Priorität bestimmt. Trifft keine Regel zu, wird abgebrochen; es wird **kein** Ersatztext erzeugt.
+6. Der schemaspezifische Generator sammelt die benötigten Dosis-/Zeitsegmente. Je nach Schema werden alle `Dosage`-Elemente oder nur das erste verarbeitet; die genaue Aggregation ist unter [Aggregation mehrerer Dosage-Elemente](#aggregation-mehrerer-dosage-elemente) festgelegt.
+7. Der Generator setzt Zeitrahmen, Bedarfsangaben, Rhythmus und Kerntext zusammen. Danach werden – außer bei Freitext – Maximalmenge und `patientInstruction` ergänzt.
+8. Abschließend wird der Text – außer bei Freitext – normalisiert. Ist das erste `Dosage`-Element als Bedarf gekennzeichnet, wird zusätzlich exakt das erste Zeichen des Ergebnisses in einen Großbuchstaben umgewandelt.
 
 Das folgende Pseudocode-Gerüst zeigt den vollständigen Kontrollfluss:
 
@@ -31,12 +32,15 @@ Das folgende Pseudocode-Gerüst zeigt den vollständigen Kontrollfluss:
 dosierungen = extrahiereDosierungen(resource)
 wenn dosierungen leer: return ""
 
+wenn irgendeine dosierung timeOfDay und when gemeinsam setzt:
+  Fehler
+
 wenn irgendeine dosierung reine Bedarfsdosierung ist
 und anzahl(dosierungen) != 1:
   Fehler
 
 schema = erkenneSchema(dosierungen[0])
-wenn schema unbekannt: return "Unbekanntes Dosierungsschema: Unknown"
+wenn schema unbekannt: Fehler
 
 text = erzeugeSchemaspezifischenText(schema, dosierungen)
 wenn schema = Freitext: return text
@@ -61,6 +65,8 @@ Es wird ausschließlich `doseAndRate[0]` ausgewertet. Ist dort `doseQuantity` vo
 > Nur die untere Grenze (`low` ohne `high`) ist **nicht zulässig** und wird durch die Invariante `DoseRangeHighRequiredWhenLowPresent` ausgeschlossen.
 
 Ganzzahlige Werte werden ohne Nachkommastelle dargestellt; überflüssige Dezimalstelle und Komma entfallen (`1.0` → `1`). Dezimalwerte werden mit **deutschem Dezimalkomma** ausgegeben (z. B. `1,5`).
+
+Eine Dosis ist in **jedem** strukturierten Schema erforderlich. Fehlt `doseAndRate` ganz, bricht der Algorithmus ab — es wird weder ein Segment stillschweigend übersprungen noch eine Dosieranweisung ohne Dosis erzeugt. Profilkonformer Input enthält immer eine Dosis: `DosageStructuredRequiresBoth` erzwingt „`timing` impliziert `doseAndRate`", und für die reine Bedarfsdosierung verlangt `DosageStructuredOrFreeText` ebenfalls `doseAndRate`.
 
 `doseQuantity.value` und `doseQuantity.unit` sind für die Textgenerierung verpflichtend. Fehlt eine dieser Angaben trotz vorhandener `doseQuantity`, bricht der Algorithmus mit einem Fehler ab.
 
@@ -103,13 +109,13 @@ Aus `frequency`, `frequencyMax`, `period`, `periodMax` und `periodUnit` entsteht
 
 `{Frequenzwert}` bezeichnet entweder `frequency` allein oder `frequency bis frequencyMax`; `{Periodenwert}` entsprechend `period` allein oder `period bis periodMax`. Die Perioden-Einheit wird nach den Regeln unter [Einheiten und Pluralisierung](#einheiten-und-pluralisierung) ausgegeben. Beispiele für Bereiche sind `2 bis 3 x täglich` und `alle 2 bis 3 Tage`.
 
-Fehlen `frequency`, `period` und `periodUnit` vollständig, wird kein Intervallbaustein erzeugt. Dies ist nur bei Schemata zulässig, deren zeitlicher Bezug bereits durch `when`, `timeOfDay` oder `dayOfWeek` bestimmt wird. Für ein Intervallschema müssen die dafür erforderlichen Angaben vollständig vorhanden sein; unvollständige Intervallangaben führen zu einem Fehler.
+Fehlen `frequency`, `period` und `periodUnit` vollständig, wird kein Intervallbaustein erzeugt. Dies ist nur bei Schemata zulässig, deren zeitlicher Bezug bereits durch `when`, `timeOfDay` oder `dayOfWeek` bestimmt wird. Für ein Intervallschema müssen die dafür erforderlichen Angaben vollständig vorhanden sein; sind sie unvollständig, greift keine der Schema-Regeln und die Verarbeitung bricht ab (siehe [Fehler und Validierung](#fehler-und-validierung)).
 
 ### Einheiten und Pluralisierung
 
 Es sind zwei Arten von Einheiten zu unterscheiden:
 
-**1. Zeit-Einheiten** (aus `periodUnit`, `boundsDuration.code`, `MindestabstandZwischenGaben`): Sie werden über eine **feste Tabelle** in ihre deutsche Bezeichnung übersetzt. Die Form richtet sich ausschließlich nach dem für die Einheit verwendeten Bezugswert: **Singular genau dann, wenn dieser Wert gleich `1` ist**, sonst **Plural**. Bei einem Periodenbereich ist `periodMax` der Bezugswert; ohne `periodMax` ist es `period`.
+**1. Zeit-Einheiten** (aus `periodUnit`, `boundsDuration.code`, `MindestabstandZwischenGaben`): Sie werden über eine **feste Tabelle** in ihre deutsche Bezeichnung übersetzt. Die Form richtet sich ausschließlich nach dem für die Einheit verwendeten Bezugswert: **Singular genau dann, wenn dieser Wert gleich `1` ist**, sonst **Plural**. Bei einem Periodenbereich ist `periodMax` der Bezugswert; ohne `periodMax` ist es `period`. Bei `boundsDuration` und beim Mindestabstand ist es der jeweilige `value` (`boundsDuration` mit `1 d` ergibt daher `für 1 Tag`).
 
 | Code | Singular (Wert = 1) | Plural (sonst) |
 |------|---------------------|----------------|
@@ -121,7 +127,7 @@ Es sind zwei Arten von Einheiten zu unterscheiden:
 | `mo` | Monat | Monate |
 | `a`  | Jahr | Jahre |
 
-Ist ein Code nicht in der Tabelle enthalten, wird der Code unverändert ausgegeben (Fallback).
+Die Tabelle ist **abschließend**. Ein Code außerhalb dieser Liste führt zum Abbruch; ein roher UCUM-Code wäre in einem patientenlesbaren Text nicht verständlich. Profilkonformer Input kann diesen Fall nicht auslösen, da alle drei Quellen required gebunden sind: `periodUnit` an `PeriodUnitsOfTimeDgMPVS` (`min`, `h`, `d`, `wk`, `mo`), `boundsDuration.code` an `DurationUnitsOfTimeDgMPVS` (`d`, `wk`, `mo`, `a`) und der Mindestabstand an `MindestabstandUnitsOfTimeDgMPVS` (`min`, `h`).
 
 **2. Dosis-Einheit** (`doseQuantity.unit` / `doseRange.*.unit`, z. B. „Stück", „mg", „Kapseln", „Tropfen"): Sie wird **wörtlich und unverändert** aus dem Input übernommen und **nicht** pluralisiert. Der Numerator der Maximalmenge (`maxDosePerPeriod.numerator.unit`) entspricht der Dosis-Einheit und wird ebenfalls wörtlich übernommen.
 
@@ -138,6 +144,8 @@ Wochentage werden, sofern vorhanden, in kanonischer Reihenfolge (Montag bis Sonn
 | `fri` | freitags |
 | `sat` | samstags |
 | `sun` | sonntags |
+
+Die Tabelle ist **abschließend** und deckt die required gebundene FHIR-Codeliste `DaysOfWeek` vollständig ab.
 
 ### Konkrete Zeiten (`timeOfDay`)
 
@@ -162,6 +170,10 @@ Die unterstützten Codes werden wie folgt abgebildet:
 | `EVE` | abends |
 | `NIGHT` | zur Nacht |
 
+Die Tabelle ist **abschließend**; `when` ist required an `TimingWhenDgMPVS` gebunden, das genau diese vier Codes enthält. Ein Code außerhalb der Tabelle führt zum Abbruch — er würde sonst bei der Belegung übersprungen und ergäbe einen Text, der die zugehörige Gabe unterschlägt (etwa `0-0-0-0 Stück` trotz angegebener Dosis).
+
+Ferner dürfen `when` und `timeOfDay` nicht gemeinsam auftreten (FHIR-Basisinvariante `tim-10`); der Algorithmus bricht in diesem Fall ab.
+
 Je nach Schema erscheinen die Codes entweder als kompaktes, positionelles Muster (4‑Schema) oder als einzelne Abschnittsangaben analog zu Uhrzeiten (siehe Teil B).
 
 ### Einnahmeanlass (`asNeededFor`)
@@ -179,7 +191,11 @@ Ausgewertet werden nur Extensions mit der exakten kanonischen URL aus der [Feldr
 
 ### Mindestabstand zwischen Gaben
 
-Der Mindestabstand wird nur im Bedarfsfall ausgegeben und lautet `im Abstand von mindestens {Wert} {Zeiteinheit}`. Das Skript durchsucht `modifierExtension` nach der exakten kanonischen URL `MindestabstandZwischenGaben` und verwendet die erste passende Extension. `valueDuration`, `valueDuration.value` und `valueDuration.code` sind dann verpflichtend; der Wert muss numerisch und größer als `0` sein. Andernfalls bricht der Algorithmus mit einem Fehler ab. Die Formatierung entspricht `boundsDuration`, jedoch ohne das Wort `für`.
+Der Mindestabstand wird nur im Bedarfsfall ausgegeben und lautet `im Abstand von mindestens {Wert} {Zeiteinheit}`. Das Skript durchsucht `modifierExtension` nach der exakten kanonischen URL `MindestabstandZwischenGaben` und verwendet die erste passende Extension. `valueDuration`, `valueDuration.value` und `valueDuration.code` sind verpflichtend — im Profil auf `1..1` gesetzt und zusätzlich vom Algorithmus geprüft; der Wert muss numerisch und größer als `0` sein. Andernfalls bricht der Algorithmus mit einem Fehler ab. Die Formatierung entspricht `boundsDuration`, jedoch ohne das Wort `für`.
+
+Als Zeiteinheit sind **ausschließlich Minuten (`min`) und Stunden (`h`)** zulässig; `valueDuration.code` ist required an `MindestabstandUnitsOfTimeDgMPVS` gebunden, `valueDuration.system` ist auf UCUM festgelegt. Die Anzeigeeinheit `valueDuration.unit` muss zum Code passen (Invariante `MindestabstandUnitMatchesCode`) — der erzeugte Text leitet die Einheit aus `.code` ab, sodass ein abweichendes `.unit` sonst der Ressource widerspräche.
+
+`valueDuration.comparator` ist auf `0..0` gestrichen: Ein Mindestabstand „> 4 Stunden" wäre unbestimmt, und die Textgenerierung stellt ausschließlich den exakten Wert dar.
 
 ### Maximalmenge (`maxDosePerPeriod`)
 
@@ -190,7 +206,7 @@ Die Maximalmenge wird der Dosis nachgestellt als `nicht mehr als {Wert} {Einheit
 
 Die Einheit entspricht der Dosiereinheit.
 
-Die Maximalmenge ist **nur bei Bedarfsmedikation** (`asNeededBoolean = true`) zulässig (durchgesetzt über die Invariante `MaxDoseOnlyWhenAsNeeded`) und wird **ausschließlich im Bedarfsfall** dargestellt. In strukturierten Nicht-Bedarf-Schemata wird `maxDosePerPeriod` nicht ausgegeben.
+Die Maximalmenge ist **nur bei Bedarfsmedikation** (`asNeededBoolean = true`) zulässig (durchgesetzt über die Invariante `MaxDoseOnlyWhenAsNeeded`) und wird **ausschließlich im Bedarfsfall** dargestellt. In strukturierten Nicht-Bedarf-Schemata wird `maxDosePerPeriod` gar nicht gelesen; die nachfolgend genannten Pflichtfeldprüfungen greifen dort folglich nicht, und ein fehlerhaftes `maxDosePerPeriod` bliebe für die Textgenerierung unbemerkt.
 
 Ist `maxDosePerPeriod` vorhanden, müssen `numerator.value`, `numerator.unit`, `denominator.value` und `denominator.code` vorhanden sein. `numerator.value` muss numerisch und `numerator.unit` darf nicht leer sein. Als Nenner werden ausschließlich `1 d` und `24 h` akzeptiert. Fehlende oder andere Angaben führen zum Abbruch; es gibt keinen Fallback und keine unvollständige Ausgabe der Maximalmenge.
 
@@ -214,12 +230,12 @@ Auch `route` wird vom Algorithmus nicht gelesen oder ausgegeben; das Element ist
 
 Beim Gedankenstrich handelt es sich exakt um den Unicode-**Em-Dash** `—` (U+2014); die vier Positionen des 4‑Schemas werden mit dem ASCII-Bindestrich-Minus `-` (U+002D) getrennt.
 
-Strukturierte Schemata erzeugen keine Zeilenumbrüche; ihr Text steht in einer Zeile. Die Freitext-Dosierung durchläuft die nachfolgende Normalisierung nicht und kann daher im Feld enthaltene Zeilenumbrüche beibehalten; lediglich der unter [Freitext-Dosierung](#freitext-dosierung) beschriebene `trim` wird angewendet.
+Strukturierte Schemata erzeugen keine Zeilenumbrüche; ihr Text steht in einer Zeile. Die Freitext-Dosierung durchläuft die nachfolgende Normalisierung nicht und kann daher im Feld enthaltene Zeilenumbrüche beibehalten; lediglich der unter [Freitext-Dosierung](#freitext-dosierung) beschriebene `trim` wird angewendet. Diese Ausnahme ist notwendig, weil die Invariante `FreeTextMatchesRenderedText` exakte Gleichheit zwischen `renderedDosageInstruction` und `Dosage.text` verlangt.
 
 **Normalisierung:** Nach dem Zusammensetzen wird der Text normalisiert – dies gilt für **alle Schemata außer der Freitext-Dosierung**:
 
-* In strukturiert erzeugten Texten werden Folgen aus zwei oder mehr Leerzeichen oder Tabs unabhängig von ihrer Herkunft zu **einem** Leerzeichen reduziert. Freitext-Dosierungen werden nicht normalisiert.
-* Leerzeichen/Tabs **unmittelbar vor** den Satzzeichen `;` `:` `.` `,` werden entfernt.
+* In strukturiert erzeugten Texten wird **jede** Folge von Leerraum – Leerzeichen, Tabs und Zeilenumbrüche, unabhängig von ihrer Herkunft – zu **einem** Leerzeichen reduziert. Damit steht ein strukturiert erzeugter Text auch dann in einer Zeile, wenn ein übernommenes Freitextfeld (`patientInstruction`, Einnahmeanlass, Dosiereinheit) selbst einen Umbruch enthält. Freitext-Dosierungen werden nicht normalisiert.
+* Leerraum **unmittelbar vor** den Satzzeichen `;` `:` `.` `,` wird entfernt.
 * Führende und abschließende Leerzeichen werden entfernt (trim).
 
 Der Gedankenstrich (`—`) und Klammern bleiben dabei unangetastet.
@@ -238,6 +254,7 @@ Bevor die Bausteine zusammengesetzt werden, wird genau **ein** Darstellungsschem
 |---------|-----------|
 | `hatText` | `Dosage.text` hat einen nicht leeren Wert |
 | `hatTiming` | `Dosage.timing` hat ein nicht leeres Objekt |
+| `hatDosis` | `Dosage.doseAndRate` ist vorhanden **und** nicht leer |
 | `istBedarf` | `Dosage.asNeededBoolean = true` |
 | `hatFrequenz` | der Schlüssel `repeat.frequency` ist vorhanden (unabhängig von seinem Wert) |
 | `hatPeriode` | der Schlüssel `repeat.period` ist vorhanden (unabhängig von seinem Wert) |
@@ -258,7 +275,7 @@ Die Regeln werden **von oben nach unten** geprüft; die **erste** zutreffende Re
 
 | # | Schema | Bedingung |
 |---|--------|-----------|
-| 1 | **Freitext-Dosierung** | `hatText` **und nicht** `hatTiming` |
+| 1 | **Freitext-Dosierung** | `hatText` **und nicht** `hatTiming` **und nicht** `hatDosis` |
 | 2 | **Bedarfsmedikation (rein)** | `istBedarf` **und nicht** `hatTiming` |
 | 3 | **4-Schema** (Tageszeiten) | `hatWhenCodes` **und nicht** `hatUhrzeit` **und nicht** `hatWochentag` |
 | 4 | **Wochentags-Bezug** | `hatWochentag` **und nicht** `hatWhenCodes` **und nicht** `hatUhrzeit` |
@@ -266,7 +283,7 @@ Die Regeln werden **von oben nach unten** geprüft; die **erste** zutreffende Re
 | 6 | **Uhrzeiten-Bezug** | `hatUhrzeit` **und nicht** `hatWochentag` **und nicht** `hatWhenCodes` **und** (`istTagesmuster` **oder** es fehlen `hatFrequenz`, `hatPeriode` und `hatPeriodeneinheit` vollständig) |
 | 7 | **Kombination von Zeitintervallen** | `istNichtTagesmuster` **und** (`hatUhrzeit` **oder** `hatWhenCodes`) |
 | 8 | **Wiederkehrende Intervalle** | `istReinesIntervall` |
-| – | **Fehlertext** | trifft keine Regel zu (Ergebnis „Unknown") |
+| – | **Abbruch** | trifft keine Regel zu |
 
 > **Bedarf als Querschnittsmerkmal:** Nur der **reine** Bedarf (ohne `timing`, Regel 2) ist ein eigenes Schema. Ist zusätzlich ein `timing` vorhanden, wird über die Regeln 3–8 das strukturierte Schema bestimmt; die Bedarfskennzeichnung (`asNeededBoolean`, Einnahmeanlass, Mindestabstand, Maximalmenge) wird dann beim Zusammensetzen als Präfix/Suffix ergänzt (siehe [Schema für Bedarfsmedikation](#schema-für-bedarfsmedikation)).
 
@@ -277,10 +294,12 @@ Die Regeln werden **von oben nach unten** geprüft; die **erste** zutreffende Re
 Ein generierter Dosierungstext folgt grundsätzlich dem Aufbau:
 
 ```
-[{Zeitrahmen}] [{Intervall}]: [{Wochentag}] [{Zeit- oder Tagesabschnittsangabe} — ]je {Dosis}[. Hinweis: {Instruktionen}]
+[{Zeitrahmen}: ] [{Intervall}: ] [{Wochentag} ][{Zeit- oder Tagesabschnittsangabe} — ]je {Dosis}[. Hinweis: {Instruktionen}]
 ```
 
 `{…}` kennzeichnet einen Platzhalter, `[...]` einen optionalen Bestandteil, der nur erscheint, wenn die zugehörige Angabe vorliegt. Klammern können geschachtelt werden; eine äußere optionale Klammer entfällt vollständig, wenn alle inneren Bestandteile fehlen.
+
+> Dieses Muster dient nur der groben Orientierung; **verbindlich sind die schemaspezifischen Muster** in den folgenden Abschnitten. Zwei Punkte sind dabei zu beachten: Der **Doppelpunkt ist nicht obligatorisch** — er trennt Zeitrahmen und Intervall von der Dosis und entfällt vollständig, wenn beides fehlt (das 4‑Schema ohne Zeitrahmen lautet schlicht `1-0-2-0 Stück`). Und **Wochentags- und Intervallschemata schließen sich gegenseitig aus**; ein `{Wochentag}` steht deshalb nie rechts eines Intervall-Doppelpunkts.
 
 In den Schemata von Teil B bezeichnet `{Dosis}` den formatierten Dosiswert einschließlich optionaler Einheit, jedoch **ohne** das Wort `je`; deshalb steht in den ausgeschriebenen Mustern ausdrücklich `je {Dosis}`. Der in Teil A beschriebene vollständige Dosis-Baustein entspricht somit `je {Dosis}`.
 
@@ -289,12 +308,12 @@ Je nach Schema werden einzelne Bestandteile weggelassen oder unterschiedlich kom
 ### Schema mit Tageszeiten-Bezug (4-Schema)
 
 ```
-[[{Zeitrahmen} ]: ]<MORN>-<NOON>-<EVE>-<NIGHT> {Einheit}[. Hinweis: {Instruktionen}]
+[{Zeitrahmen}: ]<MORN>-<NOON>-<EVE>-<NIGHT> {Einheit}[. Hinweis: {Instruktionen}]
 ```
 
 Nicht belegte Positionen erhalten den Wert `0`.
 
-Die Werte werden über alle `Dosage`-Elemente eingesammelt. Für jedes Element wird dessen Dosis allen unterstützten `when`-Codes dieses Elements zugeordnet. Die Dosis-Einheit der Ausgabe stammt aus dem ersten Element mit auswertbarer Dosis. Ein unterstützter Tagesabschnitt darf nur einmal belegt sein; eine doppelte Belegung führt defensiv zu einem Fehler. Nicht unterstützte `when`-Codes werden bei der Belegung ignoriert (profilkonformer Input enthält sie nicht). `frequency`, `frequencyMax`, `period`, `periodMax` und `periodUnit` beeinflussen die Ausgabe dieses Schemas nicht.
+Die Werte werden über alle `Dosage`-Elemente eingesammelt. Für jedes Element wird dessen Dosis allen `when`-Codes dieses Elements zugeordnet. Die Dosis-Einheit der Ausgabe stammt aus dem ersten Element mit auswertbarer Dosis. Ein Tagesabschnitt darf nur einmal belegt sein; eine doppelte Belegung führt defensiv zu einem Fehler. Ein Code außerhalb der [Tagesabschnitts-Tabelle](#tagesabschnitt-when-codes) führt ebenfalls zum Abbruch. `frequency`, `frequencyMax`, `period`, `periodMax` und `periodUnit` beeinflussen die Ausgabe dieses Schemas nicht.
 
 *Beispiel:* `für 5 Tage: 1-1-1-1 Kapseln`
 
@@ -313,10 +332,10 @@ Eine `{Zeitgruppe}` enthält alle aufsteigend sortierten `timeOfDay`-Werte **ein
 ### Schema mit Wochentags-Bezug
 
 ```
-[[{Zeitrahmen} ]: ]{Wochentag} — je {Dosis}[; {Wochentag2} — je {Dosis2} …][. Hinweis: {Instruktionen}]
+[{Zeitrahmen}: ]{Wochentag} — je {Dosis}[; {Wochentag2} — je {Dosis2} …][. Hinweis: {Instruktionen}]
 ```
 
-Jeder belegte Tag bildet mit seiner Dosis ein Segment. Mehrere Segmente werden in kanonischer Reihenfolge der Wochentage sortiert und mit Semikolon getrennt; das gilt auch, wenn die Dosis zwischen mehreren oder allen Wochentagen übereinstimmt.
+Jeder belegte Tag bildet mit seiner Dosis ein Segment. Mehrere Segmente werden in kanonischer Reihenfolge der Wochentage sortiert und mit Semikolon getrennt; das gilt auch, wenn die Dosis zwischen mehreren oder allen Wochentagen übereinstimmt. `frequency`, `frequencyMax`, `period`, `periodMax` und `periodUnit` beeinflussen die Ausgabe dieses Schemas nicht; ein `periodUnit = 'wk'` erzeugt insbesondere kein zusätzliches „wöchentlich".
 
 *Beispiel:* `montags — je 1 Stück; mittwochs — je 2 Stück`
 
@@ -336,15 +355,15 @@ Die Dosis-Einheit stammt aus dem ersten Element mit auswertbarer Dosis. Wird bei
 [{Zeitrahmen} ]{Intervall}: {Zeit oder Abschnitt} — je {Dosis}[, … ][. Hinweis: {Instruktionen}]
 ```
 
-Jede Uhrzeit oder jeder Tagesabschnitt bildet gemeinsam mit seiner Dosis ein Segment. Das gilt auch, wenn die Dosis zwischen mehreren oder allen Segmenten übereinstimmt. Segmente mit Tagesabschnitten werden in der festen Reihenfolge morgens, mittags, abends, zur Nacht sortiert; Segmente mit Uhrzeiten anhand des Eingabestrings aufsteigend. Die Segmente werden mit Komma getrennt. Bei mehrfacher Belegung desselben Zeit-Schlüssels verwendet die Referenzimplementierung die Dosis des zuerst durchlaufenen zugehörigen `Dosage`-Elements; profilkonformer Input verhindert diesen Mehrdeutigkeitsfall.
+Jede Uhrzeit oder jeder Tagesabschnitt bildet gemeinsam mit seiner Dosis ein Segment. Das gilt auch, wenn die Dosis zwischen mehreren oder allen Segmenten übereinstimmt. Segmente mit Tagesabschnitten werden in der festen Reihenfolge morgens, mittags, abends, zur Nacht sortiert; Segmente mit Uhrzeiten anhand des Eingabestrings aufsteigend. Treten – bei nicht profilkonformem Input über mehrere `Dosage`-Elemente hinweg – beide Arten gemeinsam auf, stehen **alle** Tagesabschnitte vor **allen** Uhrzeiten. Die Segmente werden mit Komma getrennt. Bei mehrfacher Belegung desselben Zeit-Schlüssels verwendet die Referenzimplementierung die Dosis des zuerst durchlaufenen zugehörigen `Dosage`-Elements; profilkonformer Input verhindert diesen Mehrdeutigkeitsfall.
 
 *Beispiel:* `alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück`
 
 ### Schema für Kombinationen von Wochentagen
 
 ```
-Aufbau (mit Uhrzeiten):        [[{Zeitrahmen} ]: ]{Wochentag} {Zeit} — je {Dosis}[; …][. Hinweis: {Instruktionen}]
-Aufbau (mit Tagesabschnitten): [[{Zeitrahmen} ]: ]{Wochentag} <MORN>-<NOON>-<EVE>-<NIGHT> {Einheit}[; …][. Hinweis: {Instruktionen}]
+Aufbau (mit Uhrzeiten):        [{Zeitrahmen}: ]{Wochentag} {Zeit} — je {Dosis}[; …][. Hinweis: {Instruktionen}]
+Aufbau (mit Tagesabschnitten): [{Zeitrahmen}: ]{Wochentag} <MORN>-<NOON>-<EVE>-<NIGHT> {Einheit}[; …][. Hinweis: {Instruktionen}]
 ```
 
 Jeder belegte Tag bildet mit seinen Uhrzeiten oder seinem Tagesabschnitts-Muster ein Segment. Mehrere Segmente werden in kanonischer Reihenfolge der Wochentage sortiert und mit Semikolon getrennt; das gilt auch, wenn die Angabe zwischen mehreren oder allen Wochentagen übereinstimmt. Innerhalb eines Tages werden Uhrzeitgruppen anhand ihrer frühesten Uhrzeit sortiert. Mehrere Uhrzeiten desselben `Dosage`-Elements stehen vor einem gemeinsamen Gedankenstrich; Uhrzeitgruppen werden mit Komma getrennt. Tagesabschnitte werden zum Vier-Positionen-Muster zusammengezogen.
@@ -354,7 +373,9 @@ Jeder belegte Tag bildet mit seinen Uhrzeiten oder seinem Tagesabschnitts-Muster
 * `montags 08:00 Uhr — je 1 Stück, 12:00 Uhr — je 2 Stück; mittwochs 20:00 Uhr — je 1 Stück`
 * `montags 1-0-1-0 Stück; mittwochs 2-1-2-0 Stück`
 
-Bei der Kombination mit Tagesabschnitten stammt die gemeinsame Einheit aus dem ersten Element mit auswertbarer Dosis. Eine spätere Belegung derselben Kombination aus Wochentag und Tagesabschnitt überschreibt bei nicht profilkonformem Input die frühere.
+Bei der Kombination mit Tagesabschnitten stammt die gemeinsame Einheit aus dem ersten Element mit auswertbarer Dosis. Eine spätere Belegung derselben Kombination aus Wochentag und Tagesabschnitt überschreibt bei nicht profilkonformem Input die frühere. Wie beim reinen Wochentags-Schema beeinflussen `frequency`, `frequencyMax`, `period`, `periodMax` und `periodUnit` die Ausgabe nicht.
+
+> **Variabilität:** Enthält **irgendein** Tag einen variablen Wert (Bereich), wird die ausgeschriebene Segmentform für **alle** Tage verwendet, damit die Notation über den gesamten Text einheitlich bleibt — z. B. `montags morgens — je 1 bis 2 Stück; mittwochs abends — je 2 Stück`. Sind alle Werte fest, bleiben alle Tage kompakt (`montags 1-0-1-0 Stück; mittwochs 2-1-2-0 Stück`).
 
 ### Schema für Bedarfsmedikation
 
@@ -385,9 +406,16 @@ Bei einer **reinen Bedarfsdosierung** muss die Ressource genau ein `Dosage`-Elem
 {Text}
 ```
 
-Enthält die `Dosage` ausschließlich freien Text (`text` vorhanden, `timing` und `doseAndRate` leer), wird dieser übernommen. Bei reinem Freitext darf die Ressource **genau ein** `Dosage`-Element enthalten (Invariante `FreeTextSingleDosageOnly`), und `Dosage.text` ist `0..1`; bei profilkonformem Input gibt es also genau **ein** Textfeld. Das Skript entfernt an dessen Anfang und Ende Leerraum. Der verbleibende Inhalt wird ansonsten unverändert ausgegeben.
+Enthält die `Dosage` ausschließlich freien Text (`text` vorhanden, `timing` **und** `doseAndRate` leer), wird dieser übernommen. Alle drei Bedingungen gehören zur Erkennungsregel: Stünde neben dem Text eine strukturierte Dosis, müsste der Algorithmus raten, welche der beiden Angaben gilt — deshalb greift dann nicht die Freitext-Regel, sondern die reguläre Schema-Erkennung.
+
+Bei reinem Freitext darf die Ressource **genau ein** `Dosage`-Element enthalten (Invariante `FreeTextSingleDosageOnly`), und `Dosage.text` ist `0..1`; bei profilkonformem Input gibt es also genau **ein** Textfeld. Das Skript entfernt an dessen Anfang und Ende Leerraum. Der verbleibende Inhalt wird ansonsten unverändert ausgegeben.
 
 *Beispiel:* `Nach Bedarf bei Schmerzen`
+
+Zwei Hinweise zum Verhalten bei nicht profilkonformem Input — hier bricht der Algorithmus bewusst **nicht** ab, weil `DosageDE` beide Konstellationen lediglich als Warnung führt (`FreeTextSingleDosageOnlyWarning`, `DosageStructuredOrFreeTextWarning`) und ein Abbruch damit auch gültige DE-Instanzen träfe:
+
+* Liegen **mehrere** reine Freitext-Elemente vor, wird jeder Text einzeln getrimmt; leere Werte entfallen, die übrigen werden in Dokumentreihenfolge mit einem Leerzeichen verbunden.
+* `Dosage.text` wird in **allen strukturierten Schemata vollständig ignoriert** — das Feld wird dort ausschließlich für die Schema-Erkennung gelesen und erscheint nie im erzeugten Text.
 
 ---
 
@@ -426,12 +454,12 @@ Die folgende Tabelle nennt für jeden dynamischen Baustein den genauen Lese-Pfad
 Für **unterschiedliche** Dosierungen, die sich nicht in einem einzelnen `Dosage`-Element abbilden lassen (z. B. unterschiedliche Dosis je Wochentag oder je Uhrzeit), werden **mehrere** `Dosage`-Elemente verwendet. Invarianten (z. B. `TimingSingleDosageForTimeOfDay`, `TimingSingleDosageForWhen`) verhindern dabei eine **unnötige** Aufteilung: Mehrere Elemente sind nur zulässig, wenn sich die Dosis (Wert) unterscheidet. Für die Textgenerierung gilt:
 
 * **Segmente** (Uhrzeit-, Tagesabschnitts- und Wochentagssegmente) werden über **alle** `Dosage`-Elemente eingesammelt und gemeinsam sortiert. Ein Segment kann daher aus demselben oder aus verschiedenen `Dosage`-Einträgen stammen; im erzeugten Text erscheinen sie zusammengeführt (siehe Trennzeichen-Regeln). Dies betrifft die Schemata 4‑Schema, Uhrzeiten, Wochentage, Wochentag-Kombinationen und Intervall-Kombinationen.
-* Die **Rahmen-Angaben** – Zeitrahmen (Dauer/Start-Ende), Bedarfskennzeichen inkl. Einnahmeanlass, Mindestabstand und Maximalmenge sowie der abschließende Hinweis – werden **ausschließlich aus dem ersten** `Dosage`-Element gelesen. Es wird angenommen, dass diese Angaben über alle Elemente konsistent sind.
+* Die **Rahmen-Angaben** – Zeitrahmen (Dauer/Start-Ende), Bedarfskennzeichen inkl. Einnahmeanlass, Mindestabstand und Maximalmenge sowie der abschließende Hinweis – werden **ausschließlich aus dem ersten** `Dosage`-Element gelesen. Dass sie über alle Elemente konsistent sind, ist keine bloße Annahme, sondern wird durch Invarianten erzwungen: `TimingOnlyOneBounds` (Dauer sowie Start/Ende), `AsNeededIdentical`, `AsNeededForIdentical`, `MindestabstandIdentical`, `MaxDosePerPeriodIdentical` und `PatientInstructionIdentical`. Ohne sie könnte eine abweichende Angabe in einem späteren Element unbemerkt entfallen — bei Maximalmenge, Mindestabstand oder Bedarfskennzeichen mit unmittelbarer Auswirkung auf die Arzneimittelsicherheit.
 * Bei den Schemata **wiederkehrende Intervalle** und **reine Bedarfsmedikation** ist jeweils genau ein `Dosage`-Element zulässig. Dies erzwingen `TimingIntervalOnlyOneFrequency` beziehungsweise `AsNeededSingleDosageOnly`; eine Segment-Aggregation findet daher nicht statt.
 
 Bei profilkonformem Input ist die resultierende Reihenfolge der Segmente **deterministisch** und hängt nicht von der Reihenfolge der `Dosage`-Elemente ab (Uhrzeiten aufsteigend, Tagesabschnitte in fester Reihenfolge, Wochentage kanonisch).
 
-Die gemeinsame Dosis-Einheit aggregierender 4‑ und Wochentagsschemata wird aus der ersten angetroffenen auswertbaren Dosis übernommen. Die Profil-Invarianten müssen sicherstellen, dass Einheiten und Rahmen-Angaben über alle beteiligten Elemente konsistent sind.
+Die gemeinsame Dosis-Einheit aggregierender 4‑ und Wochentagsschemata wird aus der ersten angetroffenen auswertbaren Dosis übernommen; `DosageDoseUnitSameCode` stellt ihre Konsistenz über alle beteiligten Elemente sicher.
 
 ---
 
@@ -444,8 +472,10 @@ Für eine Übersicht der in diesem IG bereitgestellten Beispiele siehe [Beispiel
 Die formale Definition zulässiger Felder und Kombinationen liegt in den Timing- und Dosierungs-Invarianten dieses IG (siehe [Constraints](./dosierung-constraints.html)). Die Referenzimplementierung führt **keine vollständige Validierung** und keine Auflistung unzulässiger Felder durch. Ihr konkretes Fehlerverhalten lautet:
 
 * nicht unterstützter `resourceType`: Abbruch mit `ValueError("Unsupported resource type: {resourceType}")`
-* nicht klassifizierbare Merkmalskombination: Rückgabe von `Unbekanntes Dosierungsschema: Unknown`
+* nicht klassifizierbare Merkmalskombination: Abbruch mit `ValueError("Die Dosierung entspricht keinem unterstützten Dosierungsschema.")`. Es wird **kein** Ersatztext zurückgegeben — ein solcher würde als generierte Dosieranweisung publiziert und dort eine Aussage vortäuschen, die der Algorithmus nicht treffen kann.
+* `timeOfDay` und `when` im selben `Dosage`-Element (Verstoß gegen die FHIR-Basisinvariante `tim-10`): Abbruch mit `ValueError("timeOfDay und when dürfen nicht gemeinsam angegeben werden (tim-10).")`
 * mehrere `Dosage`-Elemente, sobald eines davon eine reine Bedarfsdosierung (`asNeededBoolean = true` ohne `timing`) ist: Abbruch mit `ValueError("Reine Bedarfsmedikation erlaubt genau ein Dosage-Element.")`
+* fehlendes oder leeres `doseAndRate`: Abbruch mit `ValueError("doseAndRate ist für die Textgenerierung erforderlich.")`
 * `doseAndRate[0]` ohne `doseQuantity` oder `doseRange`: Abbruch mit `ValueError("Dosisangabe in doseAndRate[0] fehlt.")`
 * `doseQuantity` ohne `.value` oder `.unit`: Abbruch mit `ValueError("doseQuantity.value ist für die Textgenerierung erforderlich.")` beziehungsweise `ValueError("doseQuantity.unit ist für die Textgenerierung erforderlich.")`
 * `doseRange` ohne erforderliche obere Grenze: Abbruch mit `ValueError("doseRange.high.value ist für die Textgenerierung erforderlich.")`; eine fehlende Einheit führt entsprechend zu `ValueError("doseRange.high.unit ist für die Textgenerierung erforderlich.")`
@@ -461,14 +491,19 @@ Die formale Definition zulässiger Felder und Kombinationen liegt in den Timing-
 * `maxDosePerPeriod` ohne `numerator.value`, `numerator.unit`, `denominator.value` oder `denominator.code`: Abbruch mit einer entsprechenden Pflichtfeldmeldung
 * nicht numerisches `maxDosePerPeriod.numerator.value`: Abbruch mit `ValueError("maxDosePerPeriod.numerator.value muss numerisch sein.")`
 * anderer Nenner als `1 d` oder `24 h`: Abbruch mit `ValueError("maxDosePerPeriod.denominator muss 1 d oder 24 h sein.")`
-* unterstützter `when`-Code ohne auswertbare Dosis in einem verarbeiteten Tagesabschnittsschema: Abbruch mit `ValueError("Tagesabschnitt (when) ohne Dosisangabe ist nicht zulässig.")`
+* `when`-Code außerhalb der [Tagesabschnitts-Tabelle](#tagesabschnitt-when-codes): Abbruch mit `ValueError("Nicht unterstützter Tagesabschnitt (when): '{code}'.")`
 * doppelte Belegung eines Tagesabschnitts im reinen 4‑Schema: Abbruch mit `ValueError("Doppelte Belegung des Tagesabschnitts '{code}' im 4-Schema.")`
+* Zeiteinheit außerhalb der [Einheiten-Tabelle](#einheiten-und-pluralisierung) in `periodUnit`, `boundsDuration.code` oder beim Mindestabstand: Abbruch mit `ValueError("Nicht unterstützte Zeiteinheit: '{code}'.")`
 
-Andere Profilverletzungen können abhängig vom fehlenden Feld zu einem unvollständigen Text, zu defensivem Fallback-Verhalten oder zu einem Laufzeitfehler führen. Deshalb muss die Profilvalidierung vor der Textgenerierung erfolgen.
+Der Algorithmus ist so ausgelegt, dass er im Zweifel **abbricht, statt einen zweifelhaften Text zu erzeugen**: Eine Angabe, die er nicht eindeutig darstellen kann, führt zum Fehler und nicht zu einem Ersatz- oder Teiltext. Die wenigen dokumentierten Ausnahmen betreffen Konstellationen, die `DosageDE` lediglich als Warnung führt (mehrere Freitext-Elemente, Freitext neben strukturierten Angaben) — dort würde ein Abbruch auch gültige DE-Instanzen treffen.
+
+Andere Profilverletzungen können je nach fehlendem Feld dennoch zu einem unvollständigen Text oder zu einem Laufzeitfehler führen. Die Profilvalidierung muss deshalb vor der Textgenerierung erfolgen.
 
 ## Versionierung
 
 Die Version des Algorithmus ist im Skript hinterlegt (`__version__`) und wird über die Extension [GeneratedDosageInstructionsMeta](./StructureDefinition-GeneratedDosageInstructionsMeta.html) an validierenden Instanzen geführt. So lassen sich Textinhalt und verwendete Algorithmus-Version nachvollziehbar prüfen.
+
+Diese Seite beschreibt den Stand **`1.1.0-beta-8`**.
 
 ## Quellen / weiterführende Hinweise
 

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -230,7 +230,24 @@ Auch `route` wird vom Algorithmus nicht gelesen oder ausgegeben; das Element ist
 * **Semikolon mit Leerzeichen** (`; `) trennt aufeinanderfolgende **Wochentagssegmente**, unabhängig davon, ob sie aus derselben oder aus verschiedenen `Dosage`-Einträgen stammen.
 * **Bindestrich** (`-`) trennt die vier Positionen des 4‑Schemas.
 
-Beim Gedankenstrich handelt es sich exakt um den Unicode-**Em-Dash** `—` (U+2014); die vier Positionen des 4‑Schemas werden mit dem ASCII-Bindestrich-Minus `-` (U+002D) getrennt.
+#### Zeichenrepertoire
+
+Die folgenden Zeichen sind für den erzeugten Text **verbindlich festgelegt**. Maßgeblich ist jeweils der Codepoint, nicht die optische Ähnlichkeit — mehrere der Zeichen haben verwechselbare Varianten, die **nicht** verwendet werden dürfen.
+
+| Zeichen | Codepoint | Name | Verwendung | Nicht verwenden |
+|---------|-----------|------|------------|-----------------|
+| `—` | U+2014 | EM DASH | Zeit-/Abschnittsangabe ↔ Dosis; Dosis ↔ Maximalmenge | `–` U+2013, `―` U+2015, `-` U+002D |
+| `-` | U+002D | HYPHEN-MINUS | die vier Positionen des 4‑Schemas | `‐` U+2010, `−` U+2212, `–` U+2013 |
+| `,` | U+002C | COMMA | Segmenttrennung **und** deutsches Dezimalkomma | `،` U+060C |
+| `;` | U+003B | SEMICOLON | Trennung von Wochentagssegmenten | `;` U+037E |
+| `:` | U+003A | COLON | Abschnittstrennung sowie Stunde:Minute | `∶` U+2236 |
+| `.` | U+002E | FULL STOP | Satzende vor `Hinweis:` sowie Tag.Monat.Jahr | `․` U+2024 |
+| `x` | U+0078 | LATIN SMALL LETTER X | Frequenzmarker in `3 x täglich` | `×` U+00D7, `✕` U+2715 |
+| ` ` | U+0020 | SPACE | einziges Trennzeichen zwischen Wörtern | `&nbsp;` U+00A0, U+2009, U+202F |
+
+Für die Umlaute in den festen Wortbestandteilen (`täglich`, `wöchentlich`, `für`) gilt die **vorkomponierte NFC-Form**: `ä` U+00E4, `ö` U+00F6, `ü` U+00FC — **nicht** die zerlegte Form aus Grundbuchstabe und kombinierendem Trema (`a` + U+0308). Der gesamte erzeugte Text ist NFC-normalisiert. Ein `ß` kommt in keinem vom Algorithmus erzeugten Wortbestandteil vor.
+
+> Nicht Teil dieses Repertoires sind Zeichen, die **unverändert aus dem Input übernommen** werden: die Dosiereinheit (`doseQuantity.unit`), der Einnahmeanlass (`asNeededFor`), der Hinweis (`patientInstruction`) und der Freitext (`Dosage.text`). Sie werden weder ersetzt noch normalisiert.
 
 Strukturierte Schemata erzeugen keine Zeilenumbrüche; ihr Text steht in einer Zeile. Die Freitext-Dosierung durchläuft die nachfolgende Normalisierung nicht und kann daher im Feld enthaltene Zeilenumbrüche beibehalten; lediglich der unter [Freitext-Dosierung](#freitext-dosierung) beschriebene `trim` wird angewendet. Diese Ausnahme ist notwendig, weil die Invariante `FreeTextMatchesRenderedText` exakte Gleichheit zwischen `renderedDosageInstruction` und `Dosage.text` verlangt.
 

--- a/scripts/medication-dosage-to-text.py
+++ b/scripts/medication-dosage-to-text.py
@@ -462,41 +462,72 @@ class MedicationDosageTextGenerator:
         if not dosage_instructions:
             return ""
 
-        time_dose_parts = []
-
-        # Process each dosage instruction
-        for dosage in dosage_instructions:
-            timing = dosage.get('timing', {})
-            repeat_element = timing.get('repeat', {})
-            time_of_day_list = repeat_element.get('timeOfDay', [])
-
-            if not time_of_day_list:
-                continue
-
-            # Format times as German time expressions (sort chronologically)
-            sorted_times = sorted(time_of_day_list)
-            formatted_times = [self._format_time_german(t) for t in sorted_times]
-
-            # Extract dose information
-            dose_text = self._extract_dose_text_with_prefix(dosage)
-
-            # Combine times and dose for this instruction; sort key = früheste Uhrzeit,
-            # damit die Segmentreihenfolge deterministisch (nicht eingabeabhängig) ist.
-            times_combined = ", ".join(formatted_times)
-            time_dose_parts.append((sorted_times[0], f"{times_combined} — {dose_text}"))
-
-        if not time_dose_parts:
+        combined_instructions = self._build_time_dose_segments(dosage_instructions)
+        if not combined_instructions:
             return ""
 
-        # Segmente aufsteigend nach Uhrzeit sortieren; Trennung mit Komma (Trennzeichen).
-        time_dose_parts.sort(key=lambda item: item[0])
-        combined_instructions = ", ".join(text for _, text in time_dose_parts)
         text = self._assemble(dosage_instructions[0], "täglich", combined_instructions)
         return self._append_trailing_instructions(text, dosage_instructions[0])
 
     # ============================================================================
     # UTILITY METHODS - Reusable functions for data extraction and formatting
     # ============================================================================
+
+    def _build_time_dose_segments(self, dosages):
+        """
+        Build the comma-separated time segments shared by the TimeOfDay schemas.
+
+        Sammelt alle Uhrzeit-Dosis-Paare über *alle* übergebenen Dosage-Elemente
+        hinweg und sortiert sie global aufsteigend anhand des unveränderten
+        timeOfDay-Eingabestrings. Die Reihenfolge der Dosage-Elemente in der
+        Ressource beeinflusst die Ausgabe damit nicht.
+
+        Unmittelbar benachbarte Uhrzeiten mit identischer Dosis werden
+        anschließend wieder zu einer Zeitgruppe vor einem gemeinsamen
+        Gedankenstrich zusammengefasst, damit die kompakte Schreibweise
+        "08:00 Uhr, 20:00 Uhr — je 1 Stück" erhalten bleibt. Trennt eine
+        abweichende Dosis zwei Uhrzeiten desselben Dosage-Elements, zerfällt
+        die Gruppe zugunsten der aufsteigenden Sortierung.
+
+        Args:
+            dosages (list): Dosage-Elemente mit timeOfDay-Angaben
+
+        Returns:
+            str: z. B. "01:00 Uhr — je 1 Stück, 18:00 Uhr — je 3 Stück,
+                 23:00 Uhr — je 1 Stück" oder "" wenn keine Uhrzeit vorliegt
+        """
+        time_dose_pairs = []
+
+        for dosage in dosages:
+            repeat_element = dosage.get('timing', {}).get('repeat', {})
+            time_of_day_list = repeat_element.get('timeOfDay', [])
+
+            if not time_of_day_list:
+                continue
+
+            dose_text = self._extract_dose_text_with_prefix(dosage)
+            for time_value in time_of_day_list:
+                # Sortierschlüssel ist der unveränderte Eingabestring: Sekunden und
+                # Sekundenbruchteile bleiben so sortierwirksam, auch wenn sie in der
+                # Ausgabe (HH:MM Uhr) entfallen. Da timeOfDay nullaufgefüllt sein
+                # muss, entspricht die lexikographische der chronologischen Ordnung.
+                time_dose_pairs.append(
+                    (time_value, self._format_time_german(time_value), dose_text))
+
+        if not time_dose_pairs:
+            return ""
+
+        time_dose_pairs.sort(key=lambda pair: pair[0])
+
+        segments = []
+        for _, formatted_time, dose_text in time_dose_pairs:
+            if segments and segments[-1][1] == dose_text:
+                segments[-1][0].append(formatted_time)
+            else:
+                segments.append(([formatted_time], dose_text))
+
+        return ", ".join(
+            f"{', '.join(times)} — {dose_text}" for times, dose_text in segments)
 
     def _extract_dose_quantity(self, dosage):
         """
@@ -1077,31 +1108,10 @@ class MedicationDosageTextGenerator:
             day_dosages = day_to_dosages[day_code]
             day_name = self.DAY_TRANSLATIONS.get(day_code, day_code)
 
-            # Generate time-dose combinations for this day
-            time_dose_parts = []
-            for dosage in day_dosages:
-                timing = dosage.get('timing', {})
-                repeat_element = timing.get('repeat', {})
-                time_list = repeat_element.get('timeOfDay', [])
-
-                if not time_list:
-                    continue
-
-                # Format times (sort chronologically)
-                sorted_times = sorted(time_list)
-                formatted_times = [self._format_time_german(t) for t in sorted_times]
-
-                # Extract dose information
-                dose_text = self._extract_dose_text_with_prefix(dosage)
-
-                # Sort key = früheste Uhrzeit -> deterministische Segmentreihenfolge.
-                times_combined = ", ".join(formatted_times)
-                time_dose_parts.append((sorted_times[0], f"{times_combined} — {dose_text}"))
-
-            # Uhrzeiten innerhalb eines Tages: aufsteigend sortiert, mit Komma getrennt.
-            if time_dose_parts:
-                time_dose_parts.sort(key=lambda item: item[0])
-                combined_times = ", ".join(text for _, text in time_dose_parts)
+            # Uhrzeiten innerhalb eines Tages: über alle Dosage-Elemente dieses
+            # Tages global aufsteigend sortiert, mit Komma getrennt.
+            combined_times = self._build_time_dose_segments(day_dosages)
+            if combined_times:
                 day_text_parts.append(f"{day_name} {combined_times}")
 
         combined_days = "; ".join(day_text_parts)

--- a/scripts/medication-dosage-to-text.py
+++ b/scripts/medication-dosage-to-text.py
@@ -8,20 +8,25 @@ in the German FHIR medication dosage implementation guide.
 
 The script supports various dosage schemas:
 - FreeText: User-provided text instructions
-- 4-Schema: Morning-noon-evening-night pattern (e.g., "1-0-2-0 Stück")  
-- TimeOfDay: Specific times (e.g., "08:00 Uhr, 20:00 Uhr — je 1 Stück")
-- DayOfWeek: Specific weekdays (e.g., "montags, mittwochs — je 2 Stück")
+- AsNeeded: Pure as-needed dosage (e.g., "Bei Kopfschmerzen: je 1 Stück")
+- 4-Schema: Morning-noon-evening-night pattern (e.g., "1-0-2-0 Stück")
+- TimeOfDay: Specific times (e.g., "täglich: 08:00 Uhr, 20:00 Uhr — je 1 Stück")
+- DayOfWeek: Specific weekdays (e.g., "montags — je 1 Stück; mittwochs — je 2 Stück")
 - Interval: Regular intervals (e.g., "alle 8 Stunden: je 1 Stück")
 - Combined schemas: DayOfWeek + Time/4-Schema, Interval + Time/4-Schema
 
 Algorithm Priority (TimingOnlyOneType constraint):
-1. FreeText (has text, no timing)
-2. 4-Schema (daily frequency with 'when' codes, no timeOfDay/dayOfWeek)
-3. DayOfWeek (has dayOfWeek, daily period, no when/timeOfDay)
-4. DayOfWeek + Time/4-Schema (has dayOfWeek + timeOfDay OR when)
-5. TimeOfDay (daily period with timeOfDay, no dayOfWeek/when)
-6. Interval + Time/4-Schema (non-daily period with timeOfDay OR when)
-7. Interval (pure interval without when/timeOfDay/dayOfWeek)
+1. FreeText (has text, no timing, no doseAndRate)
+2. AsNeeded (asNeededBoolean=true, no timing)
+3. 4-Schema ('when' codes, no timeOfDay/dayOfWeek)
+4. DayOfWeek (has dayOfWeek, no when/timeOfDay)
+5. DayOfWeek + Time/4-Schema (has dayOfWeek + timeOfDay OR when)
+6. TimeOfDay (daily period with timeOfDay, no dayOfWeek/when)
+7. Interval + Time/4-Schema (non-daily period with timeOfDay OR when)
+8. Interval (pure interval without when/timeOfDay/dayOfWeek)
+
+Eine nicht klassifizierbare Merkmalskombination führt zum Abbruch; es wird kein
+Ersatztext erzeugt.
 """
 
 import json
@@ -31,7 +36,7 @@ import os
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-__version__ = "1.1.0-beta-7"
+__version__ = "1.1.0-beta-8"
 __language__ = "de-DE"
 
 class MedicationDosageTextGenerator:
@@ -123,14 +128,24 @@ class MedicationDosageTextGenerator:
 
         Examples:
             4-Schema: "1-0-2-0 Stück"
-            TimeOfDay: "täglich: 08:00 Uhr — je 1 Stück; 20:00 Uhr — je 2 Stück"
-            DayOfWeek: "montags — je 1 Stück, mittwochs — je 2 Stück"
+            TimeOfDay: "täglich: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück"
+            DayOfWeek: "montags — je 1 Stück; mittwochs — je 2 Stück"
             Interval: "alle 8 Stunden: je 1 Stück"
         """
         # Step 1: Extract dosage instructions based on resource type
         dosage_instructions = self._extract_dosage_instructions(resource)
         if not dosage_instructions:
             return ""
+
+        # timeOfDay und when schließen sich bereits auf Ebene des FHIR-Basisdatentyps
+        # Timing aus (tim-10). Ohne diese Prüfung würde je nach Schema stillschweigend
+        # eine der beiden Angaben verworfen.
+        for dosage in dosage_instructions:
+            repeat = (dosage.get("timing") or {}).get("repeat") or {}
+            if repeat.get("timeOfDay") and repeat.get("when"):
+                raise ValueError(
+                    "timeOfDay und when dürfen nicht gemeinsam angegeben werden (tim-10)."
+                )
 
         # Eine reine Bedarfsdosierung (asNeededBoolean=true ohne timing) ist
         # nicht aggregierbar und muss das einzige Dosage-Element sein. Diese
@@ -162,9 +177,14 @@ class MedicationDosageTextGenerator:
             self.SCHEMA_AS_NEEDED: self._generate_as_needed_text,
         }
 
+        # Eine nicht klassifizierbare Merkmalskombination ist nicht darstellbar. Ein
+        # Ersatztext würde als generierte Dosieranweisung publiziert werden und dort
+        # eine Aussage vortäuschen, die der Algorithmus gar nicht treffen kann.
         generator_method = text_generators.get(schema_type)
         if not generator_method:
-            return f"Unbekanntes Dosierungsschema: {schema_type}"
+            raise ValueError(
+                "Die Dosierung entspricht keinem unterstützten Dosierungsschema."
+            )
 
         result = generator_method(dosage_instructions)
 
@@ -213,13 +233,14 @@ class MedicationDosageTextGenerator:
         Determine the dosage schema type based on TimingOnlyOneType constraint logic.
 
         This method implements the priority order defined in the constraint:
-        1. FreeText: Has text but no timing structure
-        2. 4-Schema: Daily frequency with 'when' codes only
-        3. DayOfWeek: Has dayOfWeek with daily period, no timing details
-        4. DayOfWeek + Time/4-Schema: DayOfWeek plus timeOfDay OR when
-        5. TimeOfDay: Daily period with specific times only
-        6. Interval + Time/4-Schema: Non-daily period with timeOfDay OR when
-        7. Interval: Pure interval pattern without timing details
+        1. FreeText: Text without timing and without doseAndRate
+        2. AsNeeded: asNeededBoolean=true without timing
+        3. 4-Schema: 'when' codes only
+        4. DayOfWeek: Has dayOfWeek, no when/timeOfDay
+        5. DayOfWeek + Time/4-Schema: DayOfWeek plus timeOfDay OR when
+        6. TimeOfDay: Daily period with specific times only
+        7. Interval + Time/4-Schema: Non-daily period with timeOfDay OR when
+        8. Interval: Pure interval pattern without timing details
 
         Args:
             dosage_instructions (list): List of dosage instruction objects
@@ -233,8 +254,12 @@ class MedicationDosageTextGenerator:
         # Analyze the first dosage instruction (constraint ensures consistency)
         first_dosage = dosage_instructions[0]
 
-        # Schema 1: FreeText - has text but no structured timing
-        if first_dosage.get('text') and not first_dosage.get('timing'):
+        # Schema 1: FreeText - Text ohne jede strukturierte Dosierungsangabe.
+        # doseAndRate wird mitgeprüft: andernfalls würde bei widersprüchlichen Angaben
+        # der Freitext gewinnen und die strukturierte Dosis kommentarlos entfallen.
+        if (first_dosage.get('text')
+                and not first_dosage.get('timing')
+                and not first_dosage.get('doseAndRate')):
             return self.SCHEMA_FREE_TEXT
 
         # Extract timing information for further analysis
@@ -262,29 +287,29 @@ class MedicationDosageTextGenerator:
         is_pure_interval = (has_frequency and has_period and has_period_unit and
                             not has_when_codes and not has_time_of_day and not has_day_of_week)
 
-        # Schema 2: 4-Schema - 'when' codes only (frequency/period optional)
+        # Schema 3: 4-Schema - 'when' codes only (frequency/period optional)
         if (has_when_codes and not has_time_of_day and not has_day_of_week):
             return self.SCHEMA_4_PATTERN
 
-        # Schema 3: DayOfWeek - specific weekdays, no timing details
+        # Schema 4: DayOfWeek - specific weekdays, no timing details
         if (has_day_of_week and not has_when_codes and not has_time_of_day):
             return self.SCHEMA_DAY_OF_WEEK
 
-        # Schema 4: DayOfWeek + Time/4-Schema - weekdays plus timing
+        # Schema 5: DayOfWeek + Time/4-Schema - weekdays plus timing
         if (has_day_of_week and (has_time_of_day or has_when_codes)):
             return self.SCHEMA_DAY_TIME_COMBO
 
-        # Schema 5: TimeOfDay - specific times only. If no period is specified,
+        # Schema 6: TimeOfDay - specific times only. If no period is specified,
         # the time-of-day pattern is still interpreted as a daily schedule.
         if (has_time_of_day and not has_day_of_week and not has_when_codes and
                 (is_daily_pattern or (not has_frequency and not has_period and not has_period_unit))):
             return self.SCHEMA_TIME_OF_DAY
 
-        # Schema 6: Interval + Time/4-Schema - non-daily period with timing
+        # Schema 7: Interval + Time/4-Schema - non-daily period with timing
         if (is_non_daily_pattern and (has_time_of_day or has_when_codes)):
             return self.SCHEMA_INTERVAL_TIME_COMBO
 
-        # Schema 7: Interval - pure interval without timing details
+        # Schema 8: Interval - pure interval without timing details
         if is_pure_interval:
             return self.SCHEMA_INTERVAL
 
@@ -325,22 +350,20 @@ class MedicationDosageTextGenerator:
             when_codes = repeat_element.get('when', [])
 
             # Extract dose quantity information
-            dose_info = self._extract_dose_quantity(dosage)
-            if when_codes and not dose_info:
-                raise ValueError("Tagesabschnitt (when) ohne Dosisangabe ist nicht zulässig.")
-            if dose_info:
-                dose_value, dose_unit = dose_info
-                if not unit_text:
-                    unit_text = dose_unit
+            dose_value, dose_unit = self._extract_dose_quantity(dosage)
+            if not unit_text:
+                unit_text = dose_unit
 
-                # Assign dose value to each specified time period
-                for when_code in when_codes:
-                    if when_code in dose_amounts:
-                        if when_code in assigned_slots:
-                            raise ValueError(
-                                f"Doppelte Belegung des Tagesabschnitts '{when_code}' im 4-Schema.")
-                        assigned_slots.add(when_code)
-                        dose_amounts[when_code] = dose_value
+            # Assign dose value to each specified time period
+            for when_code in when_codes:
+                if when_code not in dose_amounts:
+                    raise ValueError(
+                        f"Nicht unterstützter Tagesabschnitt (when): '{when_code}'.")
+                if when_code in assigned_slots:
+                    raise ValueError(
+                        f"Doppelte Belegung des Tagesabschnitts '{when_code}' im 4-Schema.")
+                assigned_slots.add(when_code)
+                dose_amounts[when_code] = dose_value
 
         # Feste Dosen -> kompakt "1-0-2-0"; sobald eine Position variabel ist,
         # wird gemäß Option 2 die ausgeschriebene Segmentform verwendet
@@ -349,7 +372,7 @@ class MedicationDosageTextGenerator:
         text = self._assemble(dosage_instructions[0], "", dose_pattern)
         return self._append_trailing_instructions(text, dosage_instructions[0])
 
-    def _render_when_doses(self, dose_amounts, unit_text):
+    def _render_when_doses(self, dose_amounts, unit_text, force_written=False):
         """
         Render eine MORN/NOON/EVE/NIGHT-Dosisbelegung.
 
@@ -357,9 +380,15 @@ class MedicationDosageTextGenerator:
         "1-0-2-0 [Einheit]". Sobald eine Position variabel ist (Bereich, z. B.
         "1 bis 2"), wird das Schema gemäß Option 2 in die ausgeschriebene
         Segmentform überführt: nur belegte (nicht-null) Positionen erscheinen als
-        "morgens — je 1 bis 2 Stück; abends — je 2 Stück".
+        "morgens — je 1 bis 2 Stück, abends — je 2 Stück".
+
+        `force_written` erzwingt die ausgeschriebene Form auch für eine für sich
+        genommen feste Belegung. Die Wochentags-Kombination nutzt das, damit die
+        Notation über alle Tage hinweg einheitlich bleibt, sobald irgendein Tag
+        einen variablen Wert enthält.
         """
-        has_variable = any(isinstance(value, str) for value in dose_amounts.values())
+        has_variable = force_written or any(
+            isinstance(value, str) for value in dose_amounts.values())
 
         if not has_variable:
             pattern = "-".join(self._format_decimal_value(dose_amounts[code])
@@ -418,13 +447,13 @@ class MedicationDosageTextGenerator:
             dosage_instructions (list): List with timeOfDay specifications
 
         Returns:
-            str: Formatted text like "täglich: 08:00 Uhr — je 1 Stück; 20:00 Uhr — je 2 Stück"
+            str: Formatted text like "täglich: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück"
 
         Example FHIR input:
             - timing.repeat.timeOfDay = ["08:00", "20:00"]
             - doseQuantity = {value: 1, unit: "Stück"}
 
-        Example output: "täglich: 08:00 Uhr — je 1 Stück; 20:00 Uhr — je 2 Stück"
+        Example output: "täglich: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück"
         """
         if not dosage_instructions:
             return ""
@@ -449,9 +478,8 @@ class MedicationDosageTextGenerator:
 
             # Combine times and dose for this instruction; sort key = früheste Uhrzeit,
             # damit die Segmentreihenfolge deterministisch (nicht eingabeabhängig) ist.
-            if formatted_times and dose_text:
-                times_combined = ", ".join(formatted_times)
-                time_dose_parts.append((sorted_times[0], f"{times_combined} — {dose_text}"))
+            times_combined = ", ".join(formatted_times)
+            time_dose_parts.append((sorted_times[0], f"{times_combined} — {dose_text}"))
 
         if not time_dose_parts:
             return ""
@@ -474,7 +502,13 @@ class MedicationDosageTextGenerator:
             dosage (dict): Single dosage instruction
 
         Returns:
-            tuple: (dose_value, unit) or None if no dose found
+            tuple: (dose_value, unit)
+
+        Raises:
+            ValueError: Wenn keine auswertbare Dosis vorhanden ist. Profilkonformer
+                Input enthält immer eine: DosageStructuredRequiresBoth erzwingt
+                "timing implies doseAndRate", und für die reine Bedarfsdosierung
+                verlangt DosageStructuredOrFreeText ebenfalls doseAndRate.
 
         Example:
             Input: {"doseAndRate": [{"doseQuantity": {"value": 2, "unit": "Stück"}}]}
@@ -482,7 +516,7 @@ class MedicationDosageTextGenerator:
         """
         dose_and_rate = dosage.get('doseAndRate', [])
         if not dose_and_rate:
-            return None
+            raise ValueError("doseAndRate ist für die Textgenerierung erforderlich.")
 
         first_dose = dose_and_rate[0]
 
@@ -531,13 +565,9 @@ class MedicationDosageTextGenerator:
             dosage (dict): Single dosage instruction
 
         Returns:
-            str: Formatted dose like "je 1 Stück" or "" if no dose
+            str: Formatted dose like "je 1 Stück"
         """
-        dose_info = self._extract_dose_quantity(dosage)
-        if not dose_info:
-            return ""
-
-        dose_value, unit = dose_info
+        dose_value, unit = self._extract_dose_quantity(dosage)
         formatted_dose = dose_value if isinstance(dose_value, str) else self._format_decimal_value(dose_value)
 
         if unit:
@@ -646,12 +676,18 @@ class MedicationDosageTextGenerator:
 
     def _normalize_whitespace(self, text):
         """
-        Reduziert Mehrfach-Leerzeichen zu einem Leerzeichen und entfernt
-        Leerzeichen vor Satzzeichen (: ; , .). Gedankenstrich und Klammern
+        Reduziert jede Folge von Leerraum – einschließlich Zeilenumbrüchen aus
+        übernommenen Freitextfeldern – zu einem einzelnen Leerzeichen und entfernt
+        Leerzeichen vor Satzzeichen (: ; , .). Damit steht ein strukturiert
+        erzeugter Text garantiert in einer Zeile. Gedankenstrich und Klammern
         bleiben unangetastet.
+
+        Die Freitext-Dosierung durchläuft diese Normalisierung bewusst nicht:
+        FreeTextMatchesRenderedText verlangt exakte Gleichheit von
+        renderedDosageInstruction und Dosage.text.
         """
-        text = re.sub(r'[ \t]{2,}', ' ', text)
-        text = re.sub(r'[ \t]+([;:.,])', r'\1', text)
+        text = re.sub(r'\s+', ' ', text)
+        text = re.sub(r' ([;:.,])', r'\1', text)
         return text.strip()
 
     def _format_duration_text(self, duration, prefix="", field_name="Duration"):
@@ -780,10 +816,16 @@ class MedicationDosageTextGenerator:
 
         Returns:
             str: German unit name (e.g., "Tag" vs "Tage")
+
+        Raises:
+            ValueError: Bei einem Code außerhalb der Tabelle. Ein roher UCUM-Code
+                im erzeugten Text wäre für Patientinnen und Patienten nicht lesbar.
         """
         # Choose singular or plural based on value
         unit_dict = self.TIME_UNITS_SINGULAR if value == 1 else self.TIME_UNITS_PLURAL
-        return unit_dict.get(unit, unit)  # Fallback to original unit if not found
+        if unit not in unit_dict:
+            raise ValueError(f"Nicht unterstützte Zeiteinheit: '{unit}'.")
+        return unit_dict[unit]
 
     def _generate_day_of_week_text(self, dosage_instructions):
         """
@@ -796,13 +838,13 @@ class MedicationDosageTextGenerator:
             dosage_instructions (list): List with dayOfWeek specifications
 
         Returns:
-            str: Formatted text like "montags — je 1 Stück, mittwochs — je 2 Stück"
+            str: Formatted text like "montags — je 1 Stück; mittwochs — je 2 Stück"
 
         Example FHIR input:
             - timing.repeat.dayOfWeek = ["mon", "wed"]
             - doseQuantity = {value: 1, unit: "Stück"}
 
-        Example output: "montags — je 1 Stück, mittwochs — je 2 Stück"
+        Example output: "montags — je 1 Stück; mittwochs — je 2 Stück"
         """
         if not dosage_instructions:
             return ""
@@ -817,15 +859,13 @@ class MedicationDosageTextGenerator:
             day_codes = repeat_element.get('dayOfWeek', [])
 
             # Extract dose information
-            dose_info = self._extract_dose_quantity(dosage)
-            if dose_info:
-                dose_value, dose_unit = dose_info
-                if not unit_text:
-                    unit_text = dose_unit
+            dose_value, dose_unit = self._extract_dose_quantity(dosage)
+            if not unit_text:
+                unit_text = dose_unit
 
-                # Associate this dose with each specified day
-                for day_code in day_codes:
-                    day_to_dose[day_code] = dose_value
+            # Associate this dose with each specified day
+            for day_code in day_codes:
+                day_to_dose[day_code] = dose_value
 
         if not day_to_dose:
             return ""
@@ -978,8 +1018,8 @@ class MedicationDosageTextGenerator:
             str: Formatted combination text
 
         Sub-types:
-        - DayOfWeek + TimeOfDay: "montags 08:00 Uhr — je 1 Stück, mittwochs 20:00 Uhr — je 2 Stück"
-        - DayOfWeek + When: "montags 1-0-1-0, mittwochs 2-1-2-0 Stück"
+        - DayOfWeek + TimeOfDay: "montags 08:00 Uhr — je 1 Stück; mittwochs 20:00 Uhr — je 2 Stück"
+        - DayOfWeek + When: "montags 1-0-1-0 Stück; mittwochs 2-1-2-0 Stück"
         """
         if not dosage_instructions:
             return ""
@@ -1005,7 +1045,7 @@ class MedicationDosageTextGenerator:
         """
         Generate text for DayOfWeek + TimeOfDay combination.
 
-        Example output: "montags 08:00 Uhr — je 1 Stück, mittwochs 20:00 Uhr — je 2 Stück"
+        Example output: "montags 08:00 Uhr — je 1 Stück; mittwochs 20:00 Uhr — je 2 Stück"
         """
         if not dosage_instructions:
             return ""
@@ -1051,9 +1091,8 @@ class MedicationDosageTextGenerator:
                 dose_text = self._extract_dose_text_with_prefix(dosage)
 
                 # Sort key = früheste Uhrzeit -> deterministische Segmentreihenfolge.
-                if formatted_times and dose_text:
-                    times_combined = ", ".join(formatted_times)
-                    time_dose_parts.append((sorted_times[0], f"{times_combined} — {dose_text}"))
+                times_combined = ", ".join(formatted_times)
+                time_dose_parts.append((sorted_times[0], f"{times_combined} — {dose_text}"))
 
             # Uhrzeiten innerhalb eines Tages: aufsteigend sortiert, mit Komma getrennt.
             if time_dose_parts:
@@ -1069,7 +1108,7 @@ class MedicationDosageTextGenerator:
         """
         Generate text for DayOfWeek + When combination (4-Schema pattern per day).
 
-        Example output: "montags 1-0-1-0, mittwochs 2-1-2-0 Stück"
+        Example output: "montags 1-0-1-0 Stück; mittwochs 2-1-2-0 Stück"
         """
         if not dosage_instructions:
             return ""
@@ -1086,22 +1125,20 @@ class MedicationDosageTextGenerator:
             when_codes = repeat_element.get('when', [])
 
             # Extract dose information
-            dose_info = self._extract_dose_quantity(dosage)
-            if when_codes and not dose_info:
-                raise ValueError("Tagesabschnitt (when) ohne Dosisangabe ist nicht zulässig.")
-            if dose_info:
-                dose_value, dose_unit = dose_info
-                if not unit_text:
-                    unit_text = dose_unit
+            dose_value, dose_unit = self._extract_dose_quantity(dosage)
+            if not unit_text:
+                unit_text = dose_unit
 
-                # For each day and each when code, set the dose
-                for day_code in day_codes:
-                    if day_code not in day_to_patterns:
-                        day_to_patterns[day_code] = {code: 0 for code in self.WHEN_CODES_ORDER}
+            # For each day and each when code, set the dose
+            for day_code in day_codes:
+                if day_code not in day_to_patterns:
+                    day_to_patterns[day_code] = {code: 0 for code in self.WHEN_CODES_ORDER}
 
-                    for when_code in when_codes:
-                        if when_code in day_to_patterns[day_code]:
-                            day_to_patterns[day_code][when_code] = dose_value
+                for when_code in when_codes:
+                    if when_code not in day_to_patterns[day_code]:
+                        raise ValueError(
+                            f"Nicht unterstützter Tagesabschnitt (when): '{when_code}'.")
+                    day_to_patterns[day_code][when_code] = dose_value
 
         if not day_to_patterns:
             return ""
@@ -1110,13 +1147,22 @@ class MedicationDosageTextGenerator:
         sorted_days = sorted(day_to_patterns.keys(),
                              key=lambda day: self.DAY_ORDER.index(day) if day in self.DAY_ORDER else 99)
 
+        # Die Entscheidung kompakt/ausgeschrieben fällt einmal über alle Tage, damit
+        # ein einzelner variabler Wert nicht zu zwei Notationen in einem Text führt.
+        has_variable = any(
+            isinstance(value, str)
+            for pattern in day_to_patterns.values()
+            for value in pattern.values()
+        )
+
         day_text_parts = []
         for day_code in sorted_days:
             dose_pattern = day_to_patterns[day_code]
             day_name = self.DAY_TRANSLATIONS.get(day_code, day_code)
 
             # Feste Dosen -> kompakt "1-0-1-0"; variable -> ausgeschrieben (Option 2).
-            day_content = self._render_when_doses(dose_pattern, unit_text)
+            day_content = self._render_when_doses(
+                dose_pattern, unit_text, force_written=has_variable)
             day_text_parts.append(f"{day_name} {day_content}")
 
         combined_days = "; ".join(day_text_parts)
@@ -1133,14 +1179,14 @@ class MedicationDosageTextGenerator:
             dosage_instructions (list): List with interval and timing information
 
         Returns:
-            str: Formatted text like "alle 2 Tage: 08:00 Uhr — je 1 Stück; 18:00 Uhr — je 2 Stück"
+            str: Formatted text like "alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück"
 
         Example FHIR input:
             - timing.repeat.frequency = 1, period = 2, periodUnit = "d"
             - timing.repeat.timeOfDay = ["08:00", "18:00"]
             - doseQuantity = {value: 1, unit: "Stück"}
 
-        Example output: "alle 2 Tage: 08:00 Uhr — je 1 Stück; 18:00 Uhr — je 2 Stück"
+        Example output: "alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück"
         """
         if not dosage_instructions:
             return ""
@@ -1168,13 +1214,14 @@ class MedicationDosageTextGenerator:
 
             # Process when code entries
             elif 'when' in repeat_element and repeat_element['when']:
-                if not self._extract_dose_quantity(dosage):
-                    raise ValueError("Tagesabschnitt (when) ohne Dosisangabe ist nicht zulässig.")
+                self._extract_dose_quantity(dosage)
                 for when_code in repeat_element['when']:
-                    if when_code in self.WHEN_CODE_TRANSLATIONS:
-                        if when_code not in time_to_dosages:
-                            time_to_dosages[when_code] = []
-                        time_to_dosages[when_code].append(dosage)
+                    if when_code not in self.WHEN_CODE_TRANSLATIONS:
+                        raise ValueError(
+                            f"Nicht unterstützter Tagesabschnitt (when): '{when_code}'.")
+                    if when_code not in time_to_dosages:
+                        time_to_dosages[when_code] = []
+                    time_to_dosages[when_code].append(dosage)
 
         # Generate time-dose text parts
         time_dose_parts = []

--- a/scripts/medication-dosage-to-text.py
+++ b/scripts/medication-dosage-to-text.py
@@ -3,8 +3,12 @@
 FHIR Medication Dosage Text Generator
 
 This script converts FHIR medication dosage instructions into human-readable German text.
-It serves as a reference implementation for the dosage text generation algorithm defined 
-in the German FHIR medication dosage implementation guide.
+
+It is an EXAMPLE implementation of the dosage text generation algorithm. The normative
+definition is the "Dosierung: Textgenerierung" page of the German FHIR medication dosage
+implementation guide — if this script and that page disagree, the page prevails.
+`__version__` therefore names the version of the algorithm being implemented, not of the
+script itself.
 
 The script supports various dosage schemas:
 - FreeText: User-provided text instructions
@@ -36,7 +40,7 @@ import os
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-__version__ = "1.1.0-beta-8"
+__version__ = "2.0.0"
 __language__ = "de-DE"
 
 class MedicationDosageTextGenerator:


### PR DESCRIPTION
This pull request introduces several important consistency checks and enhancements to the `DosageDgMP` and `TimingDgMP` FHIR profiles. The main focus is on ensuring that key dosage attributes are consistently filled across all dosage elements in a resource, which improves data integrity and supports reliable text generation. Additionally, the structure and validation of timing and minimum interval fields are tightened.

**Consistency and Validation Enhancements:**

* Added new invariants to ensure that the following fields are identical across all dosage elements in a resource: `asNeededBoolean`, `asNeededFor`, `Mindestabstand` (minimum interval), and `maxDosePerPeriod`. This prevents unnoticed discrepancies and enforces that these values are uniformly represented.
* Introduced an invariant to check that the display unit for the minimum interval (`valueDuration.unit`) matches the UCUM code (e.g., "Stunde(n)" only with code "h").
* Updated the list of obeyed invariants in `DosageDgMP` to include the new consistency checks.

**Field Structure and Cardinality:**

* Tightened the structure of the `MindestabstandZwischenGaben` extension by requiring an exact value, system, code, and unit, and explicitly forbidding the use of comparators to avoid ambiguous intervals.

**Invariant Logic Improvements:**

* Refined the logic for when the `GeneratedDosageInstructionsMeta` extension is required, now also covering pure PRN (as-needed) dosages.
* Improved the description and logic for timing bounds invariants to require that bounds (Duration or Period) are consistent across all dosage instances, including for `Period` start and end dates. [[1]](diffhunk://#diff-17facd63336d466334353eb0f1021bce2ac2ae19d2b61d21253a62314fafadd3L412-R412) [[2]](diffhunk://#diff-17facd63336d466334353eb0f1021bce2ac2ae19d2b61d21253a62314fafadd3R440-R462)