### PR TITLE
Prepare 2.0.0

### DIFF
--- a/input/fsh/examples/constraint_examples_invalid_dosage_extensions_require_dosage.fsh
+++ b/input/fsh/examples/constraint_examples_invalid_dosage_extensions_require_dosage.fsh
@@ -1,4 +1,4 @@
-Instance: INV-C-ExtRequiresDosage-MR-01
+Instance: INV-C-ExtRequiresDosage-MR
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Invalid (Request): dosage extension without dosageInstruction"
@@ -11,7 +11,7 @@ Description: "Invalid: Eine Dosierungs-Extension ist vorhanden, aber keine dosag
   * url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationRequest.renderedDosageInstruction"
   * valueMarkdown = "Morgens 1 Tablette"
 
-Instance: INV-C-ExtRequiresDosage-MD-01
+Instance: INV-C-ExtRequiresDosage-MD
 InstanceOf: MedicationDispenseDgMP
 Usage: #example
 Title: "Invalid (Dispense): dosage extension without dosageInstruction"
@@ -23,7 +23,7 @@ Description: "Invalid: Eine Dosierungs-Extension ist vorhanden, aber keine dosag
   * url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationDispense.renderedDosageInstruction"
   * valueMarkdown = "Morgens 1 Tablette"
 
-Instance: INV-C-ExtRequiresDosage-MS-01
+Instance: INV-C-ExtRequiresDosage-MS
 InstanceOf: MedicationStatementDgMP
 Usage: #example
 Title: "Invalid (Statement): dosage extension without dosage"

--- a/input/fsh/profiles/MedicationDispenseDgMP.fsh
+++ b/input/fsh/profiles/MedicationDispenseDgMP.fsh
@@ -7,12 +7,12 @@ Description: "Dieses Profil dient ausschließlich der Validierung des Implementa
 * extension contains $medicationDispense-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
   and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
-* obeys ExtRequiresDosage-MD-01
+* obeys ExtRequiresDosage-MD
 
 * dosageInstruction only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"
 
-Invariant: ExtRequiresDosage-MD-01
+Invariant: ExtRequiresDosage-MD
 Description: "Wenn eine Dosierungs-Extension (GeneratedDosageInstructionsMeta oder renderedDosageInstruction) vorhanden ist, muss mindestens eine dosageInstruction vorhanden sein."
 Expression: "(
   extension.where(

--- a/input/fsh/profiles/MedicationRequestDgMP.fsh
+++ b/input/fsh/profiles/MedicationRequestDgMP.fsh
@@ -7,12 +7,12 @@ Description: "Dieses Profil dient ausschließlich der Validierung des Implementa
 * extension contains $medicationRequest-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
   and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
-* obeys ExtRequiresDosage-MR-01
+* obeys ExtRequiresDosage-MR
 
 * dosageInstruction only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"
 
-Invariant: ExtRequiresDosage-MR-01
+Invariant: ExtRequiresDosage-MR
 Description: "Wenn eine Dosierungs-Extension (GeneratedDosageInstructionsMeta oder renderedDosageInstruction) vorhanden ist, muss mindestens eine dosageInstruction vorhanden sein."
 Expression: "(
   extension.where(

--- a/input/fsh/profiles/MedicationStatementDgMP.fsh
+++ b/input/fsh/profiles/MedicationStatementDgMP.fsh
@@ -7,12 +7,12 @@ Description: "Dieses Profil dient ausschließlich der Validierung des Implementa
 * extension contains $medicationStatement-renderedDosageInstruction-r5 named renderedDosageInstruction 0..1 MS
   and GeneratedDosageInstructionsMeta named generatedDosageInstructionsMeta 0..1 MS
 * insert MedicationCommonRuleset
-* obeys ExtRequiresDosage-MS-01
+* obeys ExtRequiresDosage-MS
 
 * dosage only DosageDgMP
   * ^short = "Angabe der Dosierinformationen strukturiert oder als Freitext"
 
-Invariant: ExtRequiresDosage-MS-01
+Invariant: ExtRequiresDosage-MS
 Description: "Wenn eine Dosierungs-Extension (GeneratedDosageInstructionsMeta oder renderedDosageInstruction) vorhanden ist, muss mindestens eine dosage vorhanden sein."
 Expression: "(
   extension.where(

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -668,7 +668,7 @@ Folgende Beispiele sind nicht valide, da sie den Constraint brechen:
 
 #### Fehler: Auf Ressourcen-Ebene
 
-Die folgende Invariante ist an den Elternressourcen modelliert, weil sie einen Fall abdeckt, in dem gar kein `Dosage`-Objekt vorliegt. Sie existiert je einmal für `MedicationRequest`, `MedicationDispense` und `MedicationStatement` (Constraint-Keys `ExtRequiresDosage-MR-01`, `-MD-01` und `-MS-01`).
+Die folgende Invariante ist an den Elternressourcen modelliert, weil sie einen Fall abdeckt, in dem gar kein `Dosage`-Objekt vorliegt. Sie existiert je einmal für `MedicationRequest`, `MedicationDispense` und `MedicationStatement` (Constraint-Keys `ExtRequiresDosage-MR`, `ExtRequiresDosage-MD` und `ExtRequiresDosage-MS`).
 
 ##### DosageExtensionsRequireDosage
 

--- a/input/pagecontent/dosierung-dgmp.md
+++ b/input/pagecontent/dosierung-dgmp.md
@@ -50,6 +50,24 @@ Die Constraints im Profil [TimingDgMP](./StructureDefinition-TimingDgMP.html) st
 
 Es ist somit bspw. nicht möglich, in einer `MedicationRequest`-Ressource, im dgMP Kontext, gleichzeitig Dosierungen mit Uhrzeiten- und Tageszeiten-Schema zu kombinieren.
 
+### Hinweise für Implementierende
+
+Wer Dosierungen im dgMP-Kontext in eigenen Profilen abbildet, muss die folgenden Punkte beachten:
+
+#### dgMP-Dosage-Profil verwenden
+
+Dosierungen sind über das Profil [DosageDgMP](./StructureDefinition-DosageDgMP.html) (inklusive [TimingDgMP](./StructureDefinition-TimingDgMP.html)) abzubilden. Im eigenen Profil ist das jeweilige Element entsprechend einzuschränken - `MedicationRequest.dosageInstruction`, `MedicationDispense.dosageInstruction` bzw. `MedicationStatement.dosage`. Nur so greifen die auf dem Dosage- und Timing-Profil definierten Invarianten (siehe [Übersicht der Timing & Dosierungs-Invarianten](./dosierung-constraints.html)).
+
+#### Von den abstrakten dgMP-Ressourcenprofilen ableiten oder `ExtRequiresDosage*` übernehmen
+
+Ein Constraint lässt sich nicht auf dem Dosage-Profil abbilden: Liegt eine Dosierungs-Extension vor, aber gar kein `Dosage`-Element, gibt es kein Objekt, an dem die Prüfung ansetzen könnte. Diese Prüfung ist deshalb an den abstrakten Profilen [MedicationRequestDgMP](./StructureDefinition-MedicationRequestDgMP.html), [MedicationDispenseDgMP](./StructureDefinition-MedicationDispenseDgMP.html) und [MedicationStatementDgMP](./StructureDefinition-MedicationStatementDgMP.html) modelliert - mit den Constraint-Keys `ExtRequiresDosage-MR`, `ExtRequiresDosage-MD` und `ExtRequiresDosage-MS` (siehe [DosageExtensionsRequireDosage](./dosierung-constraints.html#dosageextensionsrequiredosage)).
+
+Eigene Profile leiten daher entweder von dem jeweils passenden abstrakten dgMP-Profil ab oder übernehmen den zugehörigen Constraint unverändert in das eigene Profil.
+
+#### Generierten Dosierungstext ergänzen
+
+Zu jeder strukturierten Dosierung ist der Dosierungstext lokal nach der [Spezifikation der Dosis-Textgenerierung](./dosierung-textgenerierung.html) zu erzeugen und in der Extension `renderedDosageInstruction` der Ressource zu hinterlegen. Sprache und verwendete Algorithmus-Version sind in der Extension [GeneratedDosageInstructionsMeta](./StructureDefinition-GeneratedDosageInstructionsMeta.html) anzugeben. Der Constraint `DosageStructuredRequiresGeneratedText` prüft, dass diese Angaben zu einer strukturierten Dosierung vorliegen; der Gesamtablauf ist unter [Bereitstellung des Dosierungstextes](./dosierung-text-hinzufuegen.html) beschrieben.
+
 ### Ausbaustufen
 
 Der digital gestützte Medikationsprozess unterstützt aktuell die folgenden Dosierschemata, gegliedert nach Ausbaustufen. Die jeweiligen Seiten enthalten eine fachliche Beschreibung, Beispiele und technische Hinweise zur Instanziierung.

--- a/scripts/ig-expected-error-check.py
+++ b/scripts/ig-expected-error-check.py
@@ -47,23 +47,25 @@ def extract_constraint_key(issue):
     return None
 
 
-def extract_expected_constraint_key(filename, marker="-C-"):
+def extract_expected_constraint_keys(filename, marker="-C-"):
     """
-    Extract expected key from a constraint filename.
+    Extract the candidate keys from a constraint filename, most specific first.
     Supported naming patterns include both:
     - ...<marker><Key>.json
     - ...<marker><Key>-MD.json / -MS.json
     - ...<marker><Key>-Request-01-of-05.json (and Dispense/Statement variants)
+    A key may itself end in a resource marker (e.g. ExtRequiresDosage-MD), therefore
+    both the unstripped and the stripped variant are returned as candidates.
     """
     if not filename.endswith(".json") or marker not in filename:
-        return None
+        return []
 
     # Extract everything after the marker and strip known trailing resource markers.
-    key = filename[:-5].split(marker, 1)[1]
-    key = re.sub(r"-(?:Request|Dispense|Statement|MR|MD|MS)-\d+-of-\d+$", "", key)
+    raw = filename[:-5].split(marker, 1)[1]
+    key = re.sub(r"-(?:Request|Dispense|Statement|MR|MD|MS)-\d+-of-\d+$", "", raw)
     key = re.sub(r"-(?:Request|Dispense|Statement|MR|MD|MS)$", "", key)
     key = re.sub(r"-\d+-of-\d+$", "", key)
-    return key or None
+    return [k for k in dict.fromkeys([raw, key]) if k]
 
 
 def get_resource_type_from_filename(filename):
@@ -185,15 +187,15 @@ if os.path.isdir(resources_dir):
     for filename in os.listdir(resources_dir):
         if not filename.endswith(".json"):
             continue
-        expected_key = extract_expected_constraint_key(filename, "-C-")
-        if not expected_key:
+        expected_keys = extract_expected_constraint_keys(filename, "-C-")
+        if not expected_keys:
             continue
         constraint_files_checked += 1
         observed = error_constraint_keys_by_file.get(filename, set())
-        if expected_key in observed:
+        if any(key in observed for key in expected_keys):
             constraint_files_expected_found += 1
         else:
-            constraint_missing_expected.append((filename, expected_key, sorted(observed)))
+            constraint_missing_expected.append((filename, " or ".join(expected_keys), sorted(observed)))
 
 # Check whether -W- files actually trigger the expected warning constraint key
 warning_files_checked = 0
@@ -203,15 +205,15 @@ if os.path.isdir(resources_dir):
     for filename in os.listdir(resources_dir):
         if not filename.endswith(".json"):
             continue
-        expected_key = extract_expected_constraint_key(filename, "-W-")
-        if not expected_key:
+        expected_keys = extract_expected_constraint_keys(filename, "-W-")
+        if not expected_keys:
             continue
         warning_files_checked += 1
         observed = warning_constraint_keys_by_file.get(filename, set())
-        if expected_key in observed:
+        if any(key in observed for key in expected_keys):
             warning_files_expected_found += 1
         else:
-            warning_missing_expected.append((filename, expected_key, sorted(observed)))
+            warning_missing_expected.append((filename, " or ".join(expected_keys), sorted(observed)))
 
 print("==Error Check==")
 print(f"{total_errors} Errors")


### PR DESCRIPTION
This pull request standardizes constraint key naming by removing unnecessary numeric suffixes (like `-01`) from constraint keys and updates all references, examples, and documentation accordingly. Additionally, it improves the constraint key extraction logic in the validation script to handle both old and new naming patterns, increasing robustness and maintainability.

**Constraint Key Standardization:**

* Removed numeric suffixes (e.g., `-01`) from constraint keys for dosage-related invariants in profiles (`MedicationRequestDgMP`, `MedicationDispenseDgMP`, `MedicationStatementDgMP`) and updated all references in examples and documentation to the new keys (`ExtRequiresDosage-MR`, `ExtRequiresDosage-MD`, `ExtRequiresDosage-MS`). [[1]](diffhunk://#diff-8cad0a1f6d54defd4401a27fe817c86aae5aa7545497d82d7cd48f638d158d02L10-R15) [[2]](diffhunk://#diff-437095c174b36fd7a88b660e7f6dda2e7c765609cb1313271c9030079ae594d0L10-R15) [[3]](diffhunk://#diff-73b0b70dbb3d9eb515c1db65c969293e6228371c06eef5290a15c749ccc1f4b7L10-R15) [[4]](diffhunk://#diff-cd91c0ed9e6e4b70aa0382e74ed00d8eaee2d00ef484350324f7a0368d64a3dcL1-R1) [[5]](diffhunk://#diff-cd91c0ed9e6e4b70aa0382e74ed00d8eaee2d00ef484350324f7a0368d64a3dcL14-R14) [[6]](diffhunk://#diff-cd91c0ed9e6e4b70aa0382e74ed00d8eaee2d00ef484350324f7a0368d64a3dcL26-R26) [[7]](diffhunk://#diff-4bbdcc34f30d260fdc5d2ad38413261344db86bd9dc77c746a54b381bcd7e144L671-R671)

* Updated documentation to reflect the new constraint key names and provided clearer guidance for implementers on how to use or inherit these constraints in custom profiles.

**Validation Script Improvements:**

* Refactored the constraint key extraction logic in `ig-expected-error-check.py` to support both the old and new naming patterns, returning all candidate keys for robust matching. Updated the script to check for any of the possible keys when validating expected constraint keys in test resources. [[1]](diffhunk://#diff-9c6467c2eb3a6dbdff4446d95cd712e92c4e62518eb730992547e5cc23e25294L50-R68) [[2]](diffhunk://#diff-9c6467c2eb3a6dbdff4446d95cd712e92c4e62518eb730992547e5cc23e25294L188-R198) [[3]](diffhunk://#diff-9c6467c2eb3a6dbdff4446d95cd712e92c4e62518eb730992547e5cc23e25294L206-R216)