### PR TITLE
Prepare 2.0.0

### DIFF
--- a/REVIEW-Planung-vs-Umsetzung-Dosierungstextgenerierung.md
+++ b/REVIEW-Planung-vs-Umsetzung-Dosierungstextgenerierung.md
@@ -1,0 +1,512 @@
+# Review: Planung vs. technische Umsetzung der Dosierungstextgenerierung
+
+**Planungsstand:** [`ERPCHANGES-ErweiterteDosisTextgenerierung-270726-1059-182.md`](./ERPCHANGES-ErweiterteDosisTextgenerierung-270726-1059-182.md)  
+**Umgesetzte Spezifikation:** [`input/pagecontent/dosierung-textgenerierung.md`](./input/pagecontent/dosierung-textgenerierung.md)  
+**Review-Datum:** 29.07.2026
+
+## Ziel und Abgrenzung
+
+Dieses Review beschreibt, was sich zwischen der fachlichen Planung und der nach der technischen Umsetzung entstandenen Spezifikation geändert hat. Verglichen wird der Inhalt der beiden Markdown-Dateien. Es handelt sich nicht um einen erneuten Abgleich der Spezifikation mit dem Python-Skript oder den FSH-Profilen.
+
+Redaktionelle Artefakte der PDF-Konvertierung, beispielsweise getrennte Wörter oder beschädigte Markdown-Formatierung, werden nicht als fachliche Änderungen gewertet.
+
+## Kurzfazit
+
+Aus dem Planungsdokument mit dem Status „IN ARBEIT“ ist eine normative, implementierbare Algorithmus-Spezifikation in Version **2.0.0** geworden.
+
+Die im Verlauf des Planungsdokuments festgehaltenen fachlichen Entscheidungen wurden weitgehend übernommen:
+
+- Bereiche werden mit „bis“ dargestellt; ein variables 4-Schema wird ausgeschrieben.
+- Die Bedarfsmedikation wird einzeilig dargestellt.
+- Der Doppelpunkt steht direkt hinter dem Einnahmeanlass beziehungsweise „bei Bedarf“.
+- Uhrzeit- und Tagesabschnittssegmente werden mit Komma, Wochentagssegmente mit Semikolon getrennt.
+- Die Nachtpause ist nicht Bestandteil des Algorithmus.
+- Der Gedankenstrich bleibt entgegen dem im Verlauf dokumentierten KBV-Prüfvorschlag erhalten.
+
+Die größten Abweichungen von der Planung sind:
+
+1. `route` wird nicht ausgegeben und ist im dgMP-Profil ausgeschlossen.
+2. Hinweise stammen nicht aus `additionalInstruction`, sondern aus `patientInstruction`.
+3. Bedarf ist kein isoliertes Darstellungsschema mehr, sondern zusätzlich ein Querschnittsmerkmal aller strukturierten Schemata.
+4. Schema-Erkennung, Mehrfach-`Dosage`-Aggregation, Normalisierung und Fehlerverhalten wurden vollständig und deterministisch festgelegt.
+5. Ein nicht unterstützter Fall erzeugt keinen publizierbaren Fehlertext mehr, sondern führt zum Abbruch.
+6. Bei Intervall-Kombinationen mit konkreten `timeOfDay`- oder `when`-Segmenten wird eine vorhandene `frequency` abweichend von der allgemeinen Planungsregel nicht mehr ausgegeben.
+
+## Übernahme der fachlichen Entscheidungen aus der Planung
+
+| Thema | Planung | Umgesetzte Spezifikation | Bewertung |
+|---|---|---|---|
+| Bereichsdarstellung | Vier Optionen; im Verlauf Vorschlag für Option 2 | Durchgängig „bis“; variables 4-Schema wird ausgeschrieben | Entscheidung übernommen |
+| Bedarfsdarstellung | Einzeiler oder Take-Wait-Stop | Ausschließlich Einzeiler | Entscheidung übernommen |
+| Doppelpunkt bei Bedarf | Ursprüngliches Muster nach Mindestabstand; im Verlauf hinter Einnahmeanlass beschlossen | Direkt hinter `bei {Anlass}` beziehungsweise `bei Bedarf` | Verlaufsvotum übernommen |
+| Segmenttrennung | Haupttext und Beispiele teilweise noch mit Semikolon für Uhrzeiten | Komma für Uhrzeiten/Tagesabschnitte, Semikolon für Wochentage | Verlaufsvotum umgesetzt und vereinheitlicht |
+| Nachtpause | Im Planungsstand bereits gestrichen | Vollständig entfallen | Übernommen |
+| Gedankenstrich | KBV schlug Entfernung vor; Entscheidung nach Heidelberg-Studie vertagt | EM DASH `—` bleibt verbindliches Trennzeichen | Offener Vorschlag nicht übernommen |
+| Verabreichungsweg | Aufnahme noch offen | `route` wird nicht gelesen; im Profil `0..0` | Bewusste Scope-Reduktion |
+| Ergänzende Hinweise | Planung über `additionalInstruction`, gegebenenfalls mehrfach | Ein einzelner Hinweis aus `patientInstruction` | Technisches FHIR-Mapping geändert |
+| Frequenz bei Intervall-Kombinationen | Allgemeiner Intervallbaustein: bei `frequency > 1` Ausgabe als `{frequency} x alle {period} {Einheit}` | Bei konkreten `timeOfDay`-/`when`-Segmenten wird nur die Periode ausgegeben; `frequency` ist optional und bleibt im Text unberücksichtigt | Bewusste, fachlich noch zu bestätigende Abweichung |
+
+## Änderungen im Detail
+
+### 1. Status und normative Verbindlichkeit
+
+**Planung**
+
+- Status „IN ARBEIT“ und „in Vorstellung“.
+- Die Referenzimplementierung prüft Felder, erkennt das Schema und erzeugt den Text.
+- Mehrere Punkte sind noch als Optionen oder als Gegenstand einer Studie formuliert.
+
+**Umsetzung**
+
+- Die Seite selbst ist die **normative Festlegung** des Algorithmus.
+- Die Python-Implementierung ist nur noch eine Beispielimplementierung. Bei Abweichungen gilt die Seite.
+- Der Algorithmus ist explizit als Version **2.0.0** bezeichnet.
+- Eine Implementierung darf dieselbe Versionsnummer verwenden, sobald sie den beschriebenen Algorithmus nachbildet.
+
+**Auswirkung**
+
+Die Verantwortlichkeit wurde umgekehrt: Nicht mehr das Skript definiert mittelbar das Verhalten, sondern die IG-Seite. Dadurch können unabhängige Implementierungen auf denselben normativen Text referenzieren.
+
+### 2. Neuer Gesamtalgorithmus
+
+Die Planung beschrieb hauptsächlich einzelne Textbausteine und Schemata. Neu hinzugekommen ist ein vollständiger Kontrollfluss:
+
+1. Auswahl der Dosierungsliste abhängig vom `resourceType`.
+2. Fehler bei nicht unterstütztem Ressourcentyp; leerer String bei leerer oder fehlender Dosierungsliste.
+3. Abbruch bei gemeinsamem `timeOfDay` und `when`.
+4. Abbruch bei mehreren `Dosage`-Elementen in Verbindung mit einer reinen Bedarfsdosierung.
+5. Schema-Erkennung allein anhand des ersten `Dosage`-Elements.
+6. Schemaspezifische Aggregation der Segmente.
+7. Ergänzung von Zeitrahmen, Bedarf, Rhythmus, Maximalmenge und Hinweis.
+8. Normalisierung und gegebenenfalls Großschreibung des ersten Zeichens.
+
+Damit ist die Reihenfolge der Verarbeitung nicht mehr nur aus den Einzelabschnitten abzuleiten.
+
+### 3. Explizite Schema-Erkennung
+
+**Planung**
+
+- Verweist darauf, dass die Referenzimplementierung das passende Schema erkennt.
+- Verweist für die formale Definition auf Invarianten.
+- Definiert keine vollständige, priorisierte Erkennungslogik.
+
+**Umsetzung**
+
+- Definiert die ausgewerteten Merkmale wie `hatText`, `hatTiming`, `hatDosis`, `hatWochentag`, `hatWhenCodes` und `hatUhrzeit`.
+- Legt abgeleitete Bedingungen wie `istTagesmuster`, `istNichtTagesmuster` und `istReinesIntervall` fest.
+- Definiert acht Erkennungsregeln in verbindlicher Prioritätsreihenfolge.
+- Die Erkennung erfolgt ausschließlich anhand des ersten `Dosage`-Elements.
+- Trifft keine Regel zu, wird abgebrochen; ein Ersatztext wird ausdrücklich nicht erzeugt.
+
+**Auswirkung**
+
+Die Schemaauswahl ist nun unabhängig von Implementierungsdetails reproduzierbar. Gleichzeitig entsteht eine klare Abhängigkeit vom ersten `Dosage`-Element; die strukturelle Konsistenz weiterer Elemente wird durch Profilinvarianten vorausgesetzt.
+
+### 4. Dosis und Bereiche
+
+**Beibehalten**
+
+- Es wird `doseAndRate[0]` verwendet.
+- Ganzzahlen erscheinen ohne Nachkommastelle.
+- Dezimalwerte verwenden das deutsche Dezimalkomma.
+- Im festen kompakten 4-Schema entfällt „je“.
+- Ein nur nach oben begrenzter Bereich wird als „bis zu“ dargestellt.
+
+**Geändert oder präzisiert**
+
+- `doseQuantity` hat ausdrücklich Vorrang vor `doseRange`.
+- Bereiche werden nicht mehr mit Bindestrich, sondern durchgängig mit **„bis“** gebildet.
+- Ein nur nach unten begrenzter `doseRange` ist unzulässig.
+- Eine Dosis ist in jedem strukturierten Schema erforderlich.
+- Pflichtfelder für `doseQuantity` und `doseRange` sind einzeln festgelegt.
+- Bei einem beidseitigen Bereich müssen die Einheiten von `low` und `high` übereinstimmen.
+- Die Ausgabeeinheit eines Bereichs stammt aus `high.unit`.
+- Weitere `doseAndRate`-Einträge werden ausdrücklich ignoriert.
+
+**Auswirkung**
+
+Die aus der Planung gewählte Option 2 wurde konsequent auf alle Bereichswerte übertragen. Zusätzlich verhindert die Spezifikation Teiltexte ohne eindeutige Dosis.
+
+### 5. Zeitrahmen
+
+#### Dauer
+
+Neu festgelegt wurden:
+
+- `boundsDuration.value` und `.code` sind Pflicht, sobald `boundsDuration` vorhanden ist.
+- Der Wert muss numerisch und größer als null sein.
+- Die Ausgabeeinheit wird aus `.code` abgeleitet.
+
+#### Start- und Endzeitpunkt
+
+Gegenüber der Planung neu oder geändert:
+
+- Ein allein vorhandenes Ende wird als `Bis zum {Enddatum}` unterstützt.
+- `boundsPeriod` und `boundsDuration` schließen einander aus.
+- `boundsPeriod` muss mindestens `start` oder `end` enthalten.
+- Es ist ein vollständiges FHIR-`dateTime`-Datum erforderlich.
+- Werte mit Uhrzeit müssen eine Zeitzone enthalten.
+- Zeitpunkte werden verbindlich nach `Europe/Berlin` umgerechnet.
+- Sekunden werden nicht ausgegeben.
+
+**Auswirkung**
+
+Insbesondere die Zeitzonenumrechnung ist eine technisch relevante Ergänzung. Sie macht auch Datumsverschiebungen durch UTC-Umrechnung und Sommerzeit deterministisch.
+
+### 6. Intervalle und Zeiteinheiten
+
+**Planung**
+
+- Beschrieb tägliche, wöchentliche und sonstige Perioden.
+- Erwähnte Bereiche für Frequenz und Periode.
+- Verwendete in den Grundregeln noch den Bindestrich.
+
+**Umsetzung**
+
+- Bezieht `frequencyMax` und `periodMax` explizit in den Algorithmus ein.
+- Unterscheidet eine feste Frequenz von genau 1, eine feste Frequenz größer als 1 und einen Frequenzbereich.
+- Verwendet auch hier durchgängig „bis“.
+- Definiert das Verhalten, wenn alle Intervallangaben fehlen.
+- Unvollständige Intervallangaben führen dazu, dass keine Schema-Regel greift.
+- Führt eine abschließende Tabelle zulässiger Zeiteinheiten ein.
+- Definiert den exakten Bezugswert für Singular und Plural.
+- Unterscheidet Zeit-Einheiten, die übersetzt und pluralisiert werden, von Dosis-Einheiten, die wörtlich übernommen werden.
+
+**Auswirkung**
+
+Die Pluralisierung und die Ausgabe von Maximalwerten sind nicht länger sprachlich implizit, sondern vollständig nachbildbar.
+
+#### Abweichung bei Intervall-Kombinationen mit konkreten Zeitpunkten
+
+**Planung / Source of Truth**
+
+Die allgemeine Intervallregel bildet bei einer festen `frequency > 1` den Text
+`{frequency} x alle {period} {Einheit}`. Da das Schema für Kombinationen von
+Zeitintervallen den Platzhalter `{Intervall}` verwendet, ergibt sich daraus
+beispielsweise:
+
+```text
+2 x alle 2 Tage: 08:00 Uhr — je 1 Stück, …
+```
+
+**Umsetzung**
+
+Bei einer Intervall-Kombination wird der gemeinsame Einnahmerhythmus nur aus
+`period`, `periodMax` und `periodUnit` gebildet. `frequency` ist optional und wird
+auch dann nicht ausgegeben, wenn sie im Eingang vorhanden ist. Die Anzahl der
+Anwendungen ergibt sich aus den explizit aufgeführten `timeOfDay`- oder
+`when`-Segmenten.
+
+Das Beispiel mit zwei `Dosage`-Elementen und fünf Einnahmezeitpunkten wird damit
+wie folgt ausgegeben:
+
+```text
+alle 2 Tage: 08:00 Uhr — je 1 Stück, 10:00 Uhr — je 2 Stück, 14:00 Uhr — je 2 Stück, 20:00 Uhr — je 1 Stück, 22:00 Uhr — je 2 Stück
+```
+
+**Begründung und Status**
+
+Bei aggregierten `Dosage`-Elementen kann jedes Element eine andere, zur jeweiligen
+Zeitpunktliste passende `frequency` besitzen. Würde nur die `frequency` des ersten
+Elements in das gemeinsame Präfix übernommen, bezöge sich beispielsweise `2 x`
+sprachlich auf alle fünf nachfolgenden Segmente und wäre missverständlich.
+
+Diese Ausnahme ist eine dokumentierte Abweichung von
+`ERPCHANGES-ErweiterteDosisTextgenerierung-270726-1059-182.md`. Die ERPCHANGE-Datei
+bleibt als Source of Truth unverändert. Die technische Abweichung bedarf daher
+noch einer fachlichen Bestätigung.
+
+### 7. Uhrzeiten, Tagesabschnitte und Wochentage
+
+**Präzisierungen**
+
+- Die Tabellen für Wochentage und `when`-Codes sind abschließend.
+- Ein unbekannter `when`-Code führt zum Abbruch.
+- `timeOfDay` akzeptiert exakt definierte Formate; ungültige Uhrzeiten führen zum Abbruch.
+- `timeOfDay` und `when` dürfen nicht gemeinsam vorkommen.
+- Sekunden und Sekundenbruchteile von `timeOfDay` entfallen in der Ausgabe.
+- Segmente werden über alle `Dosage`-Elemente eingesammelt und gemeinsam sortiert.
+- Die Reihenfolge ist damit grundsätzlich unabhängig von der Reihenfolge der `Dosage`-Elemente.
+
+**Neue Gruppierung**
+
+Unmittelbar aufeinanderfolgende Uhrzeiten mit derselben Dosis werden zu einer Zeitgruppe zusammengefasst:
+
+```text
+täglich: 08:00 Uhr, 20:00 Uhr — je 1 Stück
+```
+
+Die Planung erzeugte grundsätzlich ein eigenes Dosis-Segment je Uhrzeit.
+
+### 8. Einnahmeanlass und Bedarf
+
+**Planung**
+
+- Beschreibt `bei {Anlass}`.
+- Stellt Bedarf überwiegend als eigenes Schema dar.
+- Lässt offen, was ohne Einnahmeanlass geschieht.
+- Zeigt Mindestabstand und Doppelpunkt zunächst in einer anderen Reihenfolge.
+
+**Umsetzung**
+
+- Ohne Einnahmeanlass wird `bei Bedarf` erzeugt.
+- Mehrere `asNeededFor`-Angaben werden als deutsche Oder-Aufzählung verbunden.
+- Es wird ausschließlich `valueCodeableConcept.text` passender Extensions mit exakter kanonischer URL gelesen.
+- Leere oder unvollständige Anlassangaben führen zum Abbruch.
+- Bedarf ist ein **Querschnittsmerkmal**: Eine Bedarfskennzeichnung kann mit allen strukturierten Timing-Schemata kombiniert werden.
+- Nur Bedarf ohne `timing` ist ein eigenes Schema.
+- Eine reine Bedarfsdosierung erlaubt genau ein `Dosage`-Element.
+- Das erste Zeichen des Gesamtergebnisses wird bei Bedarf großgeschrieben.
+
+**Geänderter Einzeiler**
+
+Der Doppelpunkt steht nun direkt hinter dem Einnahmeanlass:
+
+```text
+Bei Kopfschmerzen: im Abstand von mindestens 4 Stunden je 1 Stück
+```
+
+statt des ursprünglichen Planungsmusters:
+
+```text
+Bei Kopfschmerzen im Abstand von mindestens 6 Stunden: je 1 Stück
+```
+
+### 9. Mindestabstand
+
+Die Planung verwendete den Mindestabstand im Bedarfsschema, spezifizierte sein FHIR-Mapping aber nicht vollständig.
+
+Neu festgelegt wurden:
+
+- Quelle ist die erste passende `modifierExtension` mit der exakten URL `MindestabstandZwischenGaben`.
+- `valueDuration`, `.value` und `.code` sind Pflicht.
+- Der Wert muss numerisch und größer als null sein.
+- Erlaubt sind ausschließlich Minuten und Stunden.
+- Die Einheit wird aus `.code` abgeleitet.
+- Ein Comparator ist nicht zulässig.
+- Der Mindestabstand wird nur im Bedarfsfall ausgegeben.
+
+### 10. Maximalmenge
+
+**Beibehalten**
+
+- Ausgabe als `nicht mehr als {Wert} {Einheit} {Zeitraum}`.
+- `24 h` wird als `in 24 Stunden`, `1 d` als `pro Tag` wiedergegeben.
+
+**Neu oder präzisiert**
+
+- Die Maximalmenge ist nur bei `asNeededBoolean = true` zulässig und wird nur dort gelesen.
+- Pflichtfelder von Zähler und Nenner sind vollständig definiert.
+- Nur die Nenner `24 h` und `1 d` sind zulässig.
+- Die Maximalmenge wird bei mehreren Segmenten genau einmal am Ende der gesamten Dosierungsanweisung ergänzt.
+- Ein anschließender Hinweis steht erst nach der Maximalmenge.
+
+### 11. Verabreichungsweg und Hinweise
+
+Hier liegt die deutlichste Änderung des FHIR-Mappings vor.
+
+#### Verabreichungsweg
+
+**Planung:** `route` sollte möglicherweise als deutscher EDQM-Term ausgegeben werden.  
+**Umsetzung:** `route` wird nicht gelesen oder ausgegeben und ist im Profil `DosageDgMP` auf `0..0` eingeschränkt.
+
+#### Hinweise
+
+**Planung:** Hinweise stammen aus `additionalInstruction`; mehrere Hinweise werden mit Semikolon verbunden.  
+**Umsetzung:** Hinweise stammen aus dem einzelnen String `patientInstruction` (`0..1`). `additionalInstruction` wird nicht verwendet und ist im Profil auf `0..0` gesetzt.
+
+Zusätzlich wurden folgende Regeln festgelegt:
+
+- Führender und abschließender Leerraum wird entfernt.
+- Ein leerer Hinweis wird nicht ausgegeben.
+- Der Hinweis wird als eigener Satz mit `Hinweis:` angehängt.
+- Vor `Hinweis:` wird genau ein abschließender Punkt sichergestellt.
+
+**Auswirkung**
+
+Die geplante Semikolon-Verkettung mehrerer strukturierter Hinweise entfällt. Stattdessen gibt es genau einen freien Einnahmehinweis.
+
+### 12. Trennzeichen, Unicode und Normalisierung
+
+Die in der Planung beschlossenen Trennzeichen wurden übernommen und technisch präzisiert:
+
+- Doppelpunkt: Trennung von Rahmen/Bedarf/Intervall und Kerntext.
+- EM DASH `—`: Verbindung von Zeit oder Tagesabschnitt und Dosis sowie von Dosis und Maximalmenge.
+- Komma: Trennung von Uhrzeit- und Tagesabschnittssegmenten.
+- Semikolon: Trennung von Wochentagssegmenten.
+- HYPHEN-MINUS `-`: ausschließlich Positionstrenner im kompakten 4-Schema.
+
+Neu hinzugekommen sind:
+
+- verbindliche Unicode-Codepoints für alle erzeugten Satz- und Trennzeichen;
+- `x` statt des Multiplikationszeichens `×`;
+- U+0020 als einziges erzeugtes Leerzeichen;
+- NFC-Normalisierung der erzeugten festen Wortbestandteile;
+- Reduktion jeder Leerraumfolge auf ein Leerzeichen;
+- Entfernung von Leerraum vor `;`, `:`, `.`, `,`;
+- keine Normalisierung der unverändert übernommenen Freitext-Dosierung.
+
+Der im Planungsverlauf erwähnte Vorschlag, den Gedankenstrich zu entfernen, wurde damit nicht umgesetzt.
+
+### 13. Änderungen an den einzelnen Schemata
+
+#### 4-Schema
+
+- Option 2 ist verbindlich umgesetzt.
+- Feste Werte bleiben kompakt.
+- Bei einem Bereich wird in Tagesabschnittssegmente ausgeschrieben.
+- Doppelte Belegung eines Tagesabschnitts führt zum Fehler.
+- Frequenz- und Periodenangaben beeinflussen die Darstellung nicht.
+- Bei Wochentagskombinationen wird die ausgeschriebene Form für alle Tage verwendet, sobald irgendein Tag einen Bereich enthält.
+
+#### Uhrzeiten-Bezug
+
+- Uhrzeiten werden ressourcenweit sortiert.
+- Benachbarte Uhrzeiten mit gleicher Dosis werden gruppiert.
+- Mehrere Gruppen werden mit Komma statt Semikolon getrennt.
+- Der Marker ist immer `täglich`; vorhandene Frequenzwerte werden nicht zusätzlich ausgegeben.
+
+#### Wochentags-Bezug
+
+- Wochentage bleiben einzelne, mit Semikolon getrennte Segmente.
+- Frequenz- und Periodenwerte werden in diesem Schema ausdrücklich ignoriert.
+- Für nicht profilkonforme Doppelbelegungen ist festgelegt, dass die später durchlaufene Dosis gewinnt.
+
+#### Wiederkehrende Intervalle
+
+- Eine Dosis ist zwingend.
+- Es ist genau ein `Dosage`-Element zulässig.
+- Die gestrichene Nachtpause ist vollständig entfernt.
+
+#### Kombination von Zeitintervallen
+
+- Zeit- und Tagesabschnittssegmente werden mit Komma getrennt.
+- Für defensiv verarbeiteten, nicht profilkonformen Mischinput ist die Reihenfolge festgelegt: Tagesabschnitte vor Uhrzeiten.
+- Bei mehrfacher Belegung desselben Zeitschlüssels gewinnt das zuerst durchlaufene Element.
+- `period` und `periodUnit` bestimmen den gemeinsamen Einnahmerhythmus; `frequency` ist optional und wird nicht ausgegeben.
+- Nicht tägliche Kombinationen mit `when` werden als Intervall-Kombination und nicht als reines 4-Schema erkannt.
+- Die unterdrückte Frequenzausgabe ist eine dokumentierte, fachlich noch zu bestätigende Abweichung von der ERPCHANGE-Source-of-Truth.
+
+#### Kombination von Wochentagen
+
+- Innerhalb eines Tages können Uhrzeiten gleicher Dosis gruppiert werden.
+- Zwischen Uhrzeitgruppen steht ein Komma, zwischen Wochentagen ein Semikolon.
+- Bei variablen Tagesabschnittsdosen wird die Notation über alle Tage hinweg einheitlich ausgeschrieben.
+- Frequenz- und Periodenwerte beeinflussen die Ausgabe nicht.
+
+#### Bedarfsmedikation
+
+- Ausschließlich die einzeilige Option wurde übernommen.
+- Bedarf kann zusätzlich zu einem strukturierten Schema auftreten.
+- Mindestabstand, strukturiertes Schema und Dosis stehen rechts des Doppelpunkts.
+- Die Maximalmenge wird einmal am Ende angefügt.
+- Der generische Anlass `bei Bedarf` wurde ergänzt.
+- Die Take-Wait-Stop-Darstellung mit Zeilenumbrüchen ist entfallen.
+
+#### Freitext
+
+- Profilkonform ist genau ein reines Freitext-`Dosage`-Element zulässig.
+- Der Text wird an Anfang und Ende getrimmt, ansonsten aber nicht verändert oder normalisiert.
+- Weitere Bausteine wie Maximalmenge und `patientInstruction` werden nicht angehängt.
+- Bei nicht profilkonformen mehreren Freitext-Elementen bleibt als defensives Verhalten die Verkettung der getrimmten Texte bestehen.
+- `Dosage.text` wird in strukturierten Schemata vollständig ignoriert.
+
+### 14. Mehrfach-`Dosage`-Aggregation
+
+Dieser Bereich war in der Planung nur über einzelne Sortier- und Trennregeln angedeutet. Die Umsetzung legt nun fest:
+
+- Zeit-, Tagesabschnitts- und Wochentagssegmente werden über alle `Dosage`-Elemente gesammelt.
+- Rahmenangaben werden ausschließlich aus dem ersten `Dosage`-Element gelesen.
+- Dazu zählen Zeitraum, Bedarfskennzeichen, Einnahmeanlass, Mindestabstand, Maximalmenge und Hinweis.
+- Profilinvarianten müssen die Gleichheit dieser Angaben über alle Elemente sicherstellen.
+- Wiederkehrende Intervalle und reine Bedarfsdosierungen erlauben nur ein `Dosage`-Element.
+- Die gemeinsame Dosis-Einheit aggregierender Schemata stammt aus dem ersten Element mit auswertbarer Dosis.
+- Die Ausgabereihenfolge ist bei profilkonformem Input deterministisch und unabhängig von der Eingabereihenfolge.
+
+**Auswirkung**
+
+Die technische Umsetzung macht eine wichtige Architekturentscheidung sichtbar: Segmentdaten werden aggregiert, Rahmendaten dagegen zentral aus dem ersten Eintrag gelesen.
+
+### 15. Feldreferenz und Extension-URLs
+
+Neu hinzugekommen ist eine vollständige Feldreferenz für jeden dynamischen Textbaustein. Darin werden die tatsächlich gelesenen Unterpfade dokumentiert.
+
+Außerdem sind die exakten kanonischen URLs für
+
+- `asNeededFor` und
+- `MindestabstandZwischenGaben`
+
+festgelegt. Extensions werden nicht anhand eines Kurznamens oder Suffixes, sondern nur über die exakte URL erkannt.
+
+### 16. Fehler und Validierung
+
+**Planung**
+
+- Nicht unterstützte Felder oder nicht klassifizierbare Muster sollten zu einem Fehlertext mit einer Liste betroffener Felder führen.
+
+**Umsetzung**
+
+- Ein solcher Fehlertext wird nicht mehr als Dosierungstext erzeugt.
+- Der Algorithmus bricht bei nicht eindeutig darstellbaren Angaben mit einem Fehler ab.
+- Die konkreten Fehlerfälle und überwiegend auch die `ValueError`-Texte sind dokumentiert.
+- Der Algorithmus führt trotzdem keine vollständige Profilvalidierung durch.
+- Profilvalidierung bleibt Voraussetzung.
+- Bewusste Ausnahmen bestehen bei Konstellationen, die im generischen `DosageDE` nur Warnungen sind, insbesondere mehrere reine Freitexte oder Freitext neben strukturierten Angaben.
+
+**Auswirkung**
+
+Dies ist eine sicherheitsrelevante Änderung: Ein Fehler wird nicht als scheinbar gültige generierte Dosieranweisung publiziert. Die technische Verarbeitung folgt dem Prinzip „Abbruch statt zweifelhafter Teil- oder Ersatzausgabe“.
+
+## Entfallene Planungsinhalte
+
+Folgende Inhalte sind in der umgesetzten Spezifikation nicht mehr Bestandteil des Algorithmus:
+
+- Nachtpause `(nachts Pause)`;
+- Verabreichungsweg aus `route`;
+- Hinweise aus `additionalInstruction`;
+- Verkettung mehrerer `additionalInstruction`-Hinweise mit Semikolon;
+- dreigeteilte Take-Wait-Stop-Darstellung;
+- Fehlertext als Ergebnis der Dosierungstextgenerierung;
+- Bindestrich als Bereichskonnektor;
+- mehrere getrennte Uhrzeitsegmente bei unmittelbar aufeinanderfolgenden Uhrzeiten mit gleicher Dosis.
+
+Die frühere technische Ausarbeitung mit leerer Anforderungstabelle und der chronologische Verlauf wurden nicht in die normative Algorithmusseite übernommen.
+
+## Neu hinzugekommene Inhalte
+
+Gegenüber der Planung sind insbesondere neu:
+
+- normativer Status und Algorithmus-Version 2.0.0;
+- vollständiger Gesamtalgorithmus als Ablauf und Pseudocode;
+- priorisierte Schema-Erkennung;
+- vollständige Pflichtfeld- und Fehlerregeln;
+- defensive Behandlung nicht profilkonformer Eingaben;
+- genaue Mehrfach-`Dosage`-Aggregation;
+- explizite Feldreferenz;
+- exakte Extension-URLs;
+- Zeitzonenumrechnung nach `Europe/Berlin`;
+- abschließende Tabellen zulässiger Zeit- und Tagescodes;
+- Unicode-Codepoints und NFC-Vorgaben;
+- vollständige Leerraum- und Satzzeichen-Normalisierung;
+- Gruppierung von Uhrzeiten gleicher Dosis;
+- generischer Bedarf ohne Anlass;
+- Aufzählung mehrerer Einnahmeanlässe;
+- verbindliche Position von Maximalmenge und Hinweis;
+- Dokumentation der Profileinschränkungen für `route` und `additionalInstruction`.
+
+## Gesamtbewertung
+
+Die umgesetzte Spezifikation ist keine bloße redaktionelle Fortschreibung der Planung, sondern deren technische Konsolidierung. Die fachlichen Richtungsentscheidungen aus dem Planungsverlauf wurden übernommen, während offene oder technisch nicht eindeutig abbildbare Punkte konkretisiert beziehungsweise aus dem Scope entfernt wurden.
+
+Besonders nachvollziehbar sind:
+
+- der Wechsel von einem erzeugten Fehlertext zu einem echten Abbruch;
+- die normative Prioritätsreihenfolge der Schema-Erkennung;
+- die Trennung zwischen aggregierten Segmentdaten und Rahmendaten aus dem ersten `Dosage`-Element;
+- die exakte Definition von FHIR-Pfaden, Pflichtfeldern, Codes und Extension-URLs;
+- der Ausschluss von `route` und `additionalInstruction` entsprechend dem tatsächlichen Profilumfang;
+- die Festlegung von Unicode, Normalisierung und Zeitzone für reproduzierbare Ergebnisse.
+
+Die wichtigste fachliche Erweiterung gegenüber der Planung ist die Behandlung von Bedarf als Querschnittsmerkmal. Dadurch können Einnahmeanlass, Mindestabstand und Maximalmenge mit einem regulären Timing-Schema kombiniert werden, ohne für jede Kombination ein separates Bedarfsschema definieren zu müssen.
+
+Als bewusste Implementierungsabhängigkeit bleibt bestehen, dass die Schema-Erkennung und die Rahmenangaben vom ersten `Dosage`-Element ausgehen. Die Spezifikation dokumentiert diese Abhängigkeit klar und verweist für die erforderliche Konsistenz weiterer Elemente auf Profilinvarianten.

--- a/input/fsh/datatypes/TimingDgMP.fsh
+++ b/input/fsh/datatypes/TimingDgMP.fsh
@@ -185,8 +185,15 @@ Expression: "bounds.ofType(Duration).exists().not() or (
 Severity: #error
 
 Invariant: TimingVarFreqOrPeriod
-Description: "Bei gleichzeitiger Angabe von Frequenz und Periode sollte entweder nur die Frequenz einschließlich frequencyMax oder nur die Periode einschließlich periodMax größer als 1 sein."
-Expression: "frequency.exists() and period.exists() implies
+Description: "Bei einer reinen Intervallangabe ohne Zeitpunkte sollte bei gleichzeitiger Angabe von Frequenz und Periode entweder nur die Frequenz einschließlich frequencyMax oder nur die Periode einschließlich periodMax größer als 1 sein."
+Expression: "/* Detect Interval only */
+(
+  timeOfDay.empty() and
+  when.empty() and
+  dayOfWeek.empty() and
+  frequency.exists() and
+  period.exists()
+) implies
 (
   (
     ((frequency.exists() and frequency > 1) or (frequencyMax.exists() and frequencyMax > 1))
@@ -637,7 +644,6 @@ Expression: "/* Detect Interval and Time/4-Schema */
 )
 .all(
   (
-    timing.repeat.frequency.exists() and
     timing.repeat.period.exists() and
     timing.repeat.periodUnit.exists() and
     timing.repeat.dayOfWeek.empty() and

--- a/input/fsh/examples/scheme_examples_comb_interval.fsh
+++ b/input/fsh/examples/scheme_examples_comb_interval.fsh
@@ -35,7 +35,7 @@ Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosie
   * timing.repeat
     * frequency = 1
     * period = 1
-    * periodUnit = #d
+    * periodUnit = #wk
     * when[+] = #MORN
   * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
 
@@ -67,7 +67,32 @@ Instance: Example-MR-Dosage-comb-interval-4
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-interval-4"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 & 20:00 Uhr und jeden 2. Tag 2 Stück um 08:00, 14:00 und 22:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von jeden 2. Tag 1 Stück um 08:00 und 20:00 Uhr sowie 2 Stück um 10:00, 14:00 und 22:00 Uhr dar"
+* subject.display = "Patient"
+* status = #active
+* intent = #order
+* medicationCodeableConcept.text = "Ibuprofen 400mg"
+* dosageInstruction[+]
+  * timing.repeat
+    * period = 2
+    * periodUnit = #d
+    * timeOfDay[+] = "08:00:00"
+    * timeOfDay[+] = "20:00:00"
+  * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
+* dosageInstruction[+]
+  * timing.repeat
+    * period = 2
+    * periodUnit = #d
+    * timeOfDay[+] = "10:00:00"
+    * timeOfDay[+] = "14:00:00"
+    * timeOfDay[+] = "22:00:00"
+  * doseAndRate.doseQuantity = 2 $kbv-dosiereinheit#1 "Stück"
+
+Instance: Example-MR-Dosage-comb-interval-5
+InstanceOf: MedicationRequestDgMP
+Usage: #example
+Title: "Example-MR-Dosage-comb-interval-5"
+Description: "Dieses Beispiel entspricht inhaltlich Example-MR-Dosage-comb-interval-4, gibt die redundante frequency jedoch zusätzlich an: jeden 2. Tag 1 Stück um 08:00 und 20:00 Uhr sowie 2 Stück um 10:00, 14:00 und 22:00 Uhr"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_comb_interval.fsh
+++ b/input/fsh/examples/scheme_examples_comb_interval.fsh
@@ -67,7 +67,7 @@ Instance: Example-MR-Dosage-comb-interval-4
 InstanceOf: MedicationRequestDgMP
 Usage: #example
 Title: "Example-MR-Dosage-comb-interval-4"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 & 20:00 Uhr und jeden 2. Tag 1 Stück um 08:00, 14:00 und 22:00 Uhr dar"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung von Jeden 2. Tag 1 Stück um 08:00 & 20:00 Uhr und jeden 2. Tag 2 Stück um 08:00, 14:00 und 22:00 Uhr dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order

--- a/input/fsh/examples/scheme_examples_when.fsh
+++ b/input/fsh/examples/scheme_examples_when.fsh
@@ -121,8 +121,8 @@ Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosie
 Instance: Example-MR-Dosage-1010-10-Days
 InstanceOf: MedicationRequestDgMP
 Usage: #example
-Title: "Example-MR-Dosage-1010"
-Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung 1-0-1-0 für 10 Wochen dar"
+Title: "Example-MR-Dosage-1010-10-Days"
+Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosierung 1-0-1-0 für 10 Tage dar"
 * subject.display = "Patient"
 * status = #active
 * intent = #order
@@ -131,7 +131,7 @@ Description: "Dieses Beispiel stellt eine Medikationsanforderung mit einer Dosie
   * timing.repeat
     * when[+] = #MORN
     * when[+] = #EVE
-    * boundsDuration = 10 $ucum#wk "Woche(n)"
+    * boundsDuration = 10 $ucum#d "Tag(e)"
   * doseAndRate.doseQuantity = 1 $kbv-dosiereinheit#1 "Stück"
 
 Instance: Example-MR-Dosage-1010-Unsorted

--- a/input/includes/dosage-summary-matrix.md
+++ b/input/includes/dosage-summary-matrix.md
@@ -20,7 +20,7 @@
 |  |  | 2 Stück | 1 | 2 | d |  | 21:00:00 |  |  |
 | [MedicationDispense-MD-Dosage-freetext-german-chars](./MedicationDispense-MD-Dosage-freetext-german-chars.html) | Nach dem Essen — 2 Stück täglich für 3 Wochen (Dosierung anpassen je nach Verträglichkeit) |  |  |  |  |  |  |  |  |
 | [MedicationDispense-MD-Dosage-interval-monthly](./MedicationDispense-MD-Dosage-interval-monthly.html) | alle 2 Monate: je 1 Stück | 1 Stück | 1 | 2 | mo |  |  |  |  |
-| [MedicationDispense-MD-Dosage-interval-when-3d](./MedicationDispense-MD-Dosage-interval-when-3d.html) | 1-0-2-0 Stück | 1 Stück | 1 | 3 | d |  |  | MORN |  |
+| [MedicationDispense-MD-Dosage-interval-when-3d](./MedicationDispense-MD-Dosage-interval-when-3d.html) | alle 3 Tage: morgens — je 1 Stück, abends — je 2 Stück | 1 Stück | 1 | 3 | d |  |  | MORN |  |
 |  |  | 2 Stück | 1 | 3 | d |  |  | EVE |  |
 | [MedicationDispense-MD-Dosage-multiple-day-time](./MedicationDispense-MD-Dosage-multiple-day-time.html) | montags 08:00 Uhr, 20:00 Uhr — je 2 Stück; dienstags 08:00 Uhr — je 1 Stück; donnerstags 08:00 Uhr — je 1 Stück; freitags 08:00 Uhr, 20:00 Uhr — je 2 Stück | 1 Stück | 2 | 1 | wk | tue, thu | 08:00:00 |  |  |
 |  |  | 2 Stück | 4 | 1 | wk | mon, fri | 08:00:00, 20:00:00 |  |  |
@@ -32,15 +32,15 @@
 | [MedicationRequest-Example-MR-Bug-EmptyLists](./MedicationRequest-Example-MR-Bug-EmptyLists.html) | täglich: je 1 Stück | 1 Stück | 1 | 1 | d |  |  |  |  |
 | [MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-Daily](./MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-Daily.html) | täglich: 08:00 Uhr, 14:00 Uhr, 22:00 Uhr — je 1 Stück | 1 Stück |  |  |  |  | 08:00:00, 14:00:00, 22:00:00 |  |  |
 | [MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-DayOfWeek](./MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-DayOfWeek.html) | montags 09:00 Uhr, 21:00 Uhr — je 1 Stück; mittwochs 09:00 Uhr, 21:00 Uhr — je 1 Stück; freitags 09:00 Uhr, 21:00 Uhr — je 1 Stück | 1 Stück |  |  |  | mon, wed, fri | 09:00:00, 21:00:00 |  |  |
-| [MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-Interval](./MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-Interval.html) | 2 x alle 2 Tage: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 1 Stück | 1 Stück | 2 | 2 | d |  | 08:00:00, 20:00:00 |  |  |
+| [MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-Interval](./MedicationRequest-Example-MR-Bug-MultipleTimeOfDay-Interval.html) | alle 2 Tage: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 1 Stück | 1 Stück | 2 | 2 | d |  | 08:00:00, 20:00:00 |  |  |
 | [MedicationRequest-Example-MR-Bug-MultipleWhen-DayOfWeek](./MedicationRequest-Example-MR-Bug-MultipleWhen-DayOfWeek.html) | dienstags 1-0-1-0 Stück; donnerstags 1-0-1-0 Stück | 1 Stück |  |  |  | tue, thu |  | MORN, EVE |  |
-| [MedicationRequest-Example-MR-Bug-MultipleWhen-Interval](./MedicationRequest-Example-MR-Bug-MultipleWhen-Interval.html) | 1-0-1-0 Stück | 1 Stück | 2 | 3 | d |  |  | MORN, EVE |  |
+| [MedicationRequest-Example-MR-Bug-MultipleWhen-Interval](./MedicationRequest-Example-MR-Bug-MultipleWhen-Interval.html) | alle 3 Tage: morgens — je 1 Stück, abends — je 1 Stück | 1 Stück | 2 | 3 | d |  |  | MORN, EVE |  |
 | [MedicationRequest-Example-MR-Dosage-1000-enddate](./MedicationRequest-Example-MR-Dosage-1000-enddate.html) | Bis zum 05.07.2026: 1-0-0-0 Stück | 1 Stück | 1 | 1 | d |  |  | MORN | Period =  - 2026-07-05 |
 | [MedicationRequest-Example-MR-Dosage-1000-startandenddate](./MedicationRequest-Example-MR-Dosage-1000-startandenddate.html) | Vom 05.06.2026 bis zum 05.07.2026: 1-0-0-0 Stück | 1 Stück | 1 | 1 | d |  |  | MORN | Period = 2026-06-05 - 2026-07-05 |
 | [MedicationRequest-Example-MR-Dosage-1000-startdate](./MedicationRequest-Example-MR-Dosage-1000-startdate.html) | Ab dem 05.06.2026: 1-0-0-0 Stück | 1 Stück | 1 | 1 | d |  |  | MORN | Period = 2026-06-05 - |
 | [MedicationRequest-Example-MR-Dosage-1000-startdatetime](./MedicationRequest-Example-MR-Dosage-1000-startdatetime.html) | Ab dem 06.06.2026 um 01:30 Uhr: 1-0-0-0 Stück | 1 Stück | 1 | 1 | d |  |  | MORN | Period = 2026-06-05T23:30:45Z - |
 | [MedicationRequest-Example-MR-Dosage-1000](./MedicationRequest-Example-MR-Dosage-1000.html) | 1-0-0-0 Stück | 1 Stück |  |  |  |  |  | MORN |  |
-| [MedicationRequest-Example-MR-Dosage-1010-10-Days](./MedicationRequest-Example-MR-Dosage-1010-10-Days.html) | für 10 Wochen: 1-0-1-0 Stück | 1 Stück |  |  |  |  |  | MORN, EVE | {'system': 'http://unitsofmeasure.org', 'value': 10, 'code': 'wk', 'unit': 'Woche(n)'} |
+| [MedicationRequest-Example-MR-Dosage-1010-10-Days](./MedicationRequest-Example-MR-Dosage-1010-10-Days.html) | für 10 Tage: 1-0-1-0 Stück | 1 Stück |  |  |  |  |  | MORN, EVE | {'system': 'http://unitsofmeasure.org', 'value': 10, 'code': 'd', 'unit': 'Tag(e)'} |
 | [MedicationRequest-Example-MR-Dosage-1010-PatientInstruction](./MedicationRequest-Example-MR-Dosage-1010-PatientInstruction.html) | 1-0-1-0 Stück. Hinweis: Tablette nicht zerkauen. Bei Fieber über 39 Grad Arzt kontaktieren. | 1 Stück | 2 | 1 | d |  |  | MORN, EVE |  |
 | [MedicationRequest-Example-MR-Dosage-1010-Unsorted](./MedicationRequest-Example-MR-Dosage-1010-Unsorted.html) | 1-0-1-0 Stück | 1 Stück |  |  |  |  |  | EVE, MORN |  |
 | [MedicationRequest-Example-MR-Dosage-1010](./MedicationRequest-Example-MR-Dosage-1010.html) | 1-0-1-0 Stück | 1 Stück |  |  |  |  |  | MORN, EVE |  |
@@ -57,7 +57,7 @@
 |  |  | 2 Stück |  |  |  |  |  | NOON, EVE |  |
 | [MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-Kopfschmerzen](./MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-Kopfschmerzen.html) | Bei Kopfschmerzen: im Abstand von mindestens 4 Stunden je 1 Stück — nicht mehr als 6 Stück in 24 Stunden | 1 Stück |  |  |  |  |  |  |  |
 | [MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-MehrereAnlaesse](./MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-MehrereAnlaesse.html) | Bei Kopfschmerzen, Fieber oder Gliederschmerzen: im Abstand von mindestens 6 Stunden je 1 Stück — nicht mehr als 4 Stück in 24 Stunden | 1 Stück |  |  |  |  |  |  |  |
-| [MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-Struktur-Intervall](./MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-Struktur-Intervall.html) | Bei Kopfschmerzen: im Abstand von mindestens 6 Stunden alle 8 Stunden je 1 Stück — nicht mehr als 4 Stück in 24 Stunden | 1 Stück | 1 | 8 | h |  |  |  |  |
+| [MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-Struktur-Intervall](./MedicationRequest-Example-MR-Dosage-Bedarfsmedikation-Struktur-Intervall.html) | Bei Kopfschmerzen: alle 8 Stunden je 1 Stück, mit mindestens 6 Stunden Abstand — nicht mehr als 4 Stück in 24 Stunden | 1 Stück | 1 | 8 | h |  |  |  |  |
 | [MedicationRequest-Example-MR-Dosage-Freetext](./MedicationRequest-Example-MR-Dosage-Freetext.html) | 2 Stück morgens zum Frühstück |  |  |  |  |  |  |  |  |
 | [MedicationRequest-Example-MR-Dosage-UnitStueck-1020](./MedicationRequest-Example-MR-Dosage-UnitStueck-1020.html) | 1-0-2-0 Stück | 1 Stück |  |  |  |  |  | MORN |  |
 |  |  | 2 Stück |  |  |  |  |  | EVE |  |
@@ -70,12 +70,14 @@
 | [MedicationRequest-Example-MR-Dosage-comb-dayofweek-unsorted](./MedicationRequest-Example-MR-Dosage-comb-dayofweek-unsorted.html) | montags 1-0-1-0 Stück; donnerstags 1-0-1-0 Stück; samstags 1-0-1-0 Stück | 1 Stück |  |  |  | sat, mon, thu |  | EVE, MORN |  |
 | [MedicationRequest-Example-MR-Dosage-comb-interval-1](./MedicationRequest-Example-MR-Dosage-comb-interval-1.html) | alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück | 1 Stück | 1 | 2 | d |  | 08:00:00 |  |  |
 |  |  | 2 Stück | 1 | 2 | d |  | 18:00:00 |  |  |
-| [MedicationRequest-Example-MR-Dosage-comb-interval-2](./MedicationRequest-Example-MR-Dosage-comb-interval-2.html) | 1-0-0-0 Stück | 1 Stück | 1 | 1 | d |  |  | MORN |  |
+| [MedicationRequest-Example-MR-Dosage-comb-interval-2](./MedicationRequest-Example-MR-Dosage-comb-interval-2.html) | wöchentlich: morgens — je 1 Stück | 1 Stück | 1 | 1 | wk |  |  | MORN |  |
 | [MedicationRequest-Example-MR-Dosage-comb-interval-3](./MedicationRequest-Example-MR-Dosage-comb-interval-3.html) | alle 2 Tage: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück | 1 Stück | 1 | 2 | d |  | 08:00:00 |  |  |
 |  |  | 2 Stück | 1 | 2 | d |  | 20:00:00 |  |  |
-| [MedicationRequest-Example-MR-Dosage-comb-interval-4](./MedicationRequest-Example-MR-Dosage-comb-interval-4.html) | 2 x alle 2 Tage: 08:00 Uhr — je 1 Stück, 10:00 Uhr — je 2 Stück, 14:00 Uhr — je 2 Stück, 20:00 Uhr — je 1 Stück, 22:00 Uhr — je 2 Stück | 1 Stück | 2 | 2 | d |  | 08:00:00, 20:00:00 |  |  |
+| [MedicationRequest-Example-MR-Dosage-comb-interval-4](./MedicationRequest-Example-MR-Dosage-comb-interval-4.html) | alle 2 Tage: 08:00 Uhr — je 1 Stück, 10:00 Uhr — je 2 Stück, 14:00 Uhr — je 2 Stück, 20:00 Uhr — je 1 Stück, 22:00 Uhr — je 2 Stück | 1 Stück |  | 2 | d |  | 08:00:00, 20:00:00 |  |  |
+|  |  | 2 Stück |  | 2 | d |  | 10:00:00, 14:00:00, 22:00:00 |  |  |
+| [MedicationRequest-Example-MR-Dosage-comb-interval-5](./MedicationRequest-Example-MR-Dosage-comb-interval-5.html) | alle 2 Tage: 08:00 Uhr — je 1 Stück, 10:00 Uhr — je 2 Stück, 14:00 Uhr — je 2 Stück, 20:00 Uhr — je 1 Stück, 22:00 Uhr — je 2 Stück | 1 Stück | 2 | 2 | d |  | 08:00:00, 20:00:00 |  |  |
 |  |  | 2 Stück | 3 | 2 | d |  | 10:00:00, 14:00:00, 22:00:00 |  |  |
-| [MedicationRequest-Example-MR-Dosage-interval-1mo](./MedicationRequest-Example-MR-Dosage-interval-1mo.html) | alle 1 Monat: je 1 Stück | 1 Stück | 1 | 1 | mo |  |  |  |  |
+| [MedicationRequest-Example-MR-Dosage-interval-1mo](./MedicationRequest-Example-MR-Dosage-interval-1mo.html) | monatlich: je 1 Stück | 1 Stück | 1 | 1 | mo |  |  |  |  |
 | [MedicationRequest-Example-MR-Dosage-interval-2d-bound](./MedicationRequest-Example-MR-Dosage-interval-2d-bound.html) | für 6 Wochen alle 2 Tage: je 2 Stück | 2 Stück | 1 | 2 | d |  |  |  | {'system': 'http://unitsofmeasure.org', 'value': 6, 'code': 'wk', 'unit': 'Woche(n)'} |
 | [MedicationRequest-Example-MR-Dosage-interval-2wk](./MedicationRequest-Example-MR-Dosage-interval-2wk.html) | alle 2 Wochen: je 1 Stück | 1 Stück | 1 | 2 | wk |  |  |  |  |
 | [MedicationRequest-Example-MR-Dosage-interval-30min](./MedicationRequest-Example-MR-Dosage-interval-30min.html) | alle 30 Minuten: je 1 Stück | 1 Stück | 1 | 30 | min |  |  |  |  |
@@ -107,7 +109,7 @@
 | [MedicationRequest-MR-Dosage-4schema-noon-only](./MedicationRequest-MR-Dosage-4schema-noon-only.html) | 0-1-0-0 Stück | 1 Stück |  |  |  |  |  | NOON |  |
 | [MedicationRequest-MR-Dosage-freetext-german-chars](./MedicationRequest-MR-Dosage-freetext-german-chars.html) | Nach dem Essen — 2 Stück täglich für 3 Wochen (Dosierung anpassen je nach Verträglichkeit) |  |  |  |  |  |  |  |  |
 | [MedicationRequest-MR-Dosage-interval-monthly](./MedicationRequest-MR-Dosage-interval-monthly.html) | alle 2 Monate: je 1 Stück | 1 Stück | 1 | 2 | mo |  |  |  |  |
-| [MedicationRequest-MR-Dosage-interval-when-3d](./MedicationRequest-MR-Dosage-interval-when-3d.html) | 1-0-2-0 Stück | 1 Stück | 1 | 3 | d |  |  | MORN |  |
+| [MedicationRequest-MR-Dosage-interval-when-3d](./MedicationRequest-MR-Dosage-interval-when-3d.html) | alle 3 Tage: morgens — je 1 Stück, abends — je 2 Stück | 1 Stück | 1 | 3 | d |  |  | MORN |  |
 |  |  | 2 Stück | 1 | 3 | d |  |  | EVE |  |
 | [MedicationRequest-MR-Dosage-multiple-day-time](./MedicationRequest-MR-Dosage-multiple-day-time.html) | montags 08:00 Uhr, 20:00 Uhr — je 2 Stück; dienstags 08:00 Uhr — je 1 Stück; donnerstags 08:00 Uhr — je 1 Stück; freitags 08:00 Uhr, 20:00 Uhr — je 2 Stück | 1 Stück |  |  |  | tue, thu | 08:00:00 |  |  |
 |  |  | 2 Stück |  |  |  | mon, fri | 08:00:00, 20:00:00 |  |  |
@@ -136,7 +138,7 @@
 | [MedicationStatement-MS-Dosage-interval-monthly](./MedicationStatement-MS-Dosage-interval-monthly.html) | alle 2 Monate: je 1 Stück | 1 Stück | 1 | 2 | mo |  |  |  |  |
 | [MedicationStatement-MS-Dosage-interval-time-3d](./MedicationStatement-MS-Dosage-interval-time-3d.html) | alle 3 Tage: 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück | 1 Stück | 1 | 3 | d |  | 08:00:00 |  |  |
 |  |  | 2 Stück | 1 | 3 | d |  | 20:00:00 |  |  |
-| [MedicationStatement-MS-Dosage-interval-when-3d](./MedicationStatement-MS-Dosage-interval-when-3d.html) | 1-0-2-0 Stück | 1 Stück | 1 | 3 | d |  |  | MORN |  |
+| [MedicationStatement-MS-Dosage-interval-when-3d](./MedicationStatement-MS-Dosage-interval-when-3d.html) | alle 3 Tage: morgens — je 1 Stück, abends — je 2 Stück | 1 Stück | 1 | 3 | d |  |  | MORN |  |
 |  |  | 2 Stück | 1 | 3 | d |  |  | EVE |  |
 | [MedicationStatement-MS-Dosage-multiple-day-time](./MedicationStatement-MS-Dosage-multiple-day-time.html) | montags 08:00 Uhr, 20:00 Uhr — je 2 Stück; dienstags 08:00 Uhr — je 1 Stück; donnerstags 08:00 Uhr — je 1 Stück; freitags 08:00 Uhr, 20:00 Uhr — je 2 Stück | 1 Stück |  |  |  | tue, thu | 08:00:00 |  |  |
 |  |  | 2 Stück |  |  |  | mon, fri | 08:00:00, 20:00:00 |  |  |

--- a/input/pagecontent/dosierung-constraints.md
+++ b/input/pagecontent/dosierung-constraints.md
@@ -141,10 +141,10 @@ Beispiele (Warnungskontext – variable Einzeldosis und variable Periode):
 ##### TimingVarFreqOrPeriod
 
 **Beschreibung:**  
-Bei gleichzeitiger Angabe von Frequenz und Periode sollte entweder nur die Frequenz einschließlich `frequencyMax` oder nur die Periode einschließlich `periodMax` größer als 1 sein.
+Bei einer reinen Intervallangabe ohne Zeitpunkte sollte bei gleichzeitiger Angabe von Frequenz und Periode entweder nur die Frequenz einschließlich `frequencyMax` oder nur die Periode einschließlich `periodMax` größer als 1 sein.
 
 **Warum?**  
-Die gleichzeitige Variation beider Achsen führt zu einem nur schwer eindeutig interpretierbaren Einnahmeschema.
+Die gleichzeitige Variation beider Achsen führt zu einem nur schwer eindeutig interpretierbaren Einnahmeschema. Sind zusätzlich Zeitpunkte (`timeOfDay`, `when`) oder Wochentage (`dayOfWeek`) angegeben, greift die Regel nicht: Dort entspricht `frequency` gemäß `TimingFrequencyCount` der Anzahl der Zeitpunkte und ist kein Faktor des Einnahmerhythmus.
 
 Folgende Beispiele lösen eine Warnung aus:
 

--- a/input/pagecontent/dosierung-textgenerierung.md
+++ b/input/pagecontent/dosierung-textgenerierung.md
@@ -100,18 +100,34 @@ Das Datum wird im Format `TT.MM.JJJJ`, eine vorhandene Uhrzeit im Format `HH:MM 
 
 *Beispiel:* `2026-06-05T23:30:45Z` wird in `Europe/Berlin` zu `06.06.2026 um 01:30 Uhr`.
 
-### Intervall (`frequency` / `period` / `periodUnit`)
+### Einnahmerhythmus (`frequency` / `period` / `periodUnit`)
 
 Aus `frequency`, `frequencyMax`, `period`, `periodMax` und `periodUnit` entsteht der einleitende Rhythmus:
 
 * tägliches Muster (`periodUnit='d'`, `period=1`): `täglich` bei `frequency=1` und fehlendem `frequencyMax`, sonst `{Frequenzwert} x täglich`
 * wöchentliches Muster (`periodUnit='wk'`, `period=1`): `wöchentlich` bei `frequency=1` und fehlendem `frequencyMax`, sonst `{Frequenzwert} x wöchentlich`
+* monatliches Muster (`periodUnit='mo'`, `period=1`): `monatlich` bei `frequency=1` und fehlendem `frequencyMax`, sonst `{Frequenzwert} x monatlich`
 * sonstige Perioden bei einer **festen Frequenz von genau 1** (`frequency=1`, `frequencyMax` fehlt): `alle {Periodenwert} {Einheit}` (z. B. `alle 8 Stunden`)
 * sonstige Perioden bei einem **Frequenzbereich** (`frequencyMax` vorhanden, auch bei `frequency=1`) oder einer festen Frequenz größer als 1: `{Frequenzwert} x alle {Periodenwert} {Einheit}` (z. B. `1 bis 2 x alle 8 Stunden` beziehungsweise `2 x alle 8 Stunden`)
 
 `{Frequenzwert}` bezeichnet entweder `frequency` allein oder `frequency bis frequencyMax`; `{Periodenwert}` entsprechend `period` allein oder `period bis periodMax`. Die Perioden-Einheit wird nach den Regeln unter [Einheiten und Pluralisierung](#einheiten-und-pluralisierung) ausgegeben. Beispiele für Bereiche sind `2 bis 3 x täglich` und `alle 2 bis 3 Tage`.
 
-Fehlen `frequency`, `period` und `periodUnit` vollständig, wird kein Intervallbaustein erzeugt. Dies ist nur bei Schemata zulässig, deren zeitlicher Bezug bereits durch `when`, `timeOfDay` oder `dayOfWeek` bestimmt wird. Für ein Intervallschema müssen die dafür erforderlichen Angaben vollständig vorhanden sein; sind sie unvollständig, greift keine der Schema-Regeln und die Verarbeitung bricht ab (siehe [Fehler und Validierung](#fehler-und-validierung)).
+Diese allgemeine Frequenzdarstellung gilt für das reine Intervallschema ohne
+`timeOfDay` oder `when`. Bei einer Intervall-Kombination geben die konkreten
+Zeitpunkte die Anwendungshäufigkeit bereits vollständig an. Deshalb wird dort eine
+vorhandene `frequency` nicht ausgegeben; der gemeinsame Einnahmerhythmus wird
+ausschließlich aus `period`, `periodMax` und `periodUnit` gebildet. Dabei gelten
+für `1 d`, `1 wk` und `1 mo` ebenfalls die Kurzformen `täglich`, `wöchentlich`
+und `monatlich`.
+
+Fehlen `frequency`, `period` und `periodUnit` vollständig, wird kein Baustein für
+den Einnahmerhythmus erzeugt. Dies ist nur bei Schemata zulässig, deren zeitlicher
+Bezug bereits durch `when`, `timeOfDay` oder `dayOfWeek` bestimmt wird. Das reine
+Intervallschema erfordert `frequency`, `period` und `periodUnit`; die
+Intervall-Kombination erfordert `period` und `periodUnit`, während `frequency`
+optional ist. Sind die jeweils erforderlichen Angaben unvollständig, greift keine
+der Schema-Regeln und die Verarbeitung bricht ab (siehe
+[Fehler und Validierung](#fehler-und-validierung)).
 
 ### Einheiten und Pluralisierung
 
@@ -195,7 +211,7 @@ Ausgewertet werden nur Extensions mit der exakten kanonischen URL aus der [Feldr
 
 ### Mindestabstand zwischen Gaben
 
-Der Mindestabstand wird nur im Bedarfsfall ausgegeben und lautet `im Abstand von mindestens {Wert} {Zeiteinheit}`. Der Algorithmus durchsucht `modifierExtension` nach der exakten kanonischen URL `MindestabstandZwischenGaben` und verwendet die erste passende Extension. `valueDuration`, `valueDuration.value` und `valueDuration.code` sind verpflichtend — im Profil auf `1..1` gesetzt und zusätzlich vom Algorithmus geprüft; der Wert muss numerisch und größer als `0` sein. Andernfalls bricht der Algorithmus mit einem Fehler ab. Die Formatierung entspricht `boundsDuration`, jedoch ohne das Wort `für`.
+Der Mindestabstand wird nur im Bedarfsfall ausgegeben. Bei einer reinen Bedarfsdosierung lautet der Baustein `im Abstand von mindestens {Wert} {Zeiteinheit}` und steht vor der Dosis. Ist zusätzlich ein strukturierter Einnahmerhythmus vorhanden, wird der Mindestabstand zur klaren Abgrenzung vom Rhythmus nach dem Schemakern als `, mit mindestens {Wert} {Zeiteinheit} Abstand` ausgegeben. Der Algorithmus durchsucht `modifierExtension` nach der exakten kanonischen URL `MindestabstandZwischenGaben` und verwendet die erste passende Extension. `valueDuration`, `valueDuration.value` und `valueDuration.code` sind verpflichtend — im Profil auf `1..1` gesetzt und zusätzlich vom Algorithmus geprüft; der Wert muss numerisch und größer als `0` sein. Andernfalls bricht der Algorithmus mit einem Fehler ab. Die Formatierung des Wertes und der Einheit entspricht `boundsDuration`, jedoch ohne das Wort `für`.
 
 Als Zeiteinheit sind **ausschließlich Minuten (`min`) und Stunden (`h`)** zulässig; `valueDuration.code` ist required an `MindestabstandUnitsOfTimeDgMPVS` gebunden, `valueDuration.system` ist auf UCUM festgelegt. Die Anzeigeeinheit `valueDuration.unit` muss zum Code passen (Invariante `MindestabstandUnitMatchesCode`) — der erzeugte Text leitet die Einheit aus `.code` ab, sodass ein abweichendes `.unit` sonst der Ressource widerspräche.
 
@@ -298,10 +314,10 @@ Die Regeln werden **von oben nach unten** geprüft; die **erste** zutreffende Re
 |---|--------|-----------|
 | 1 | **Freitext-Dosierung** | `hatText` **und nicht** `hatTiming` **und nicht** `hatDosis` |
 | 2 | **Bedarfsmedikation (rein)** | `istBedarf` **und nicht** `hatTiming` |
-| 3 | **4-Schema** (Tageszeiten) | `hatWhenCodes` **und nicht** `hatUhrzeit` **und nicht** `hatWochentag` |
+| 3 | **4-Schema** (Tageszeiten) | `hatWhenCodes` **und nicht** `hatUhrzeit` **und nicht** `hatWochentag` **und** (`istTagesmuster` **oder** `hatPeriode` und `hatPeriodeneinheit` fehlen vollständig) |
 | 4 | **Wochentags-Bezug** | `hatWochentag` **und nicht** `hatWhenCodes` **und nicht** `hatUhrzeit` |
 | 5 | **Kombination von Wochentagen** | `hatWochentag` **und** (`hatUhrzeit` **oder** `hatWhenCodes`) |
-| 6 | **Uhrzeiten-Bezug** | `hatUhrzeit` **und nicht** `hatWochentag` **und nicht** `hatWhenCodes` **und** (`istTagesmuster` **oder** es fehlen `hatFrequenz`, `hatPeriode` und `hatPeriodeneinheit` vollständig) |
+| 6 | **Uhrzeiten-Bezug** | `hatUhrzeit` **und nicht** `hatWochentag` **und nicht** `hatWhenCodes` **und** (`istTagesmuster` **oder** `hatPeriode` und `hatPeriodeneinheit` fehlen vollständig) |
 | 7 | **Kombination von Zeitintervallen** | `istNichtTagesmuster` **und** (`hatUhrzeit` **oder** `hatWhenCodes`) |
 | 8 | **Wiederkehrende Intervalle** | `istReinesIntervall` |
 | – | **Abbruch** | trifft keine Regel zu |
@@ -373,10 +389,15 @@ Die Dosis-Einheit stammt aus dem ersten Element mit auswertbarer Dosis. Wird bei
 ### Schema für Kombinationen von Zeitintervallen
 
 ```
-[{Zeitrahmen} ]{Intervall}: {Zeit oder Abschnitt} — je {Dosis}[, … ][. Hinweis: {Instruktionen}]
+[{Zeitrahmen} ]{Einnahmerhythmus}: {Zeit oder Abschnitt} — je {Dosis}[, … ][. Hinweis: {Instruktionen}]
 ```
 
 Jede Uhrzeit oder jeder Tagesabschnitt bildet gemeinsam mit seiner Dosis ein Segment. Das gilt auch, wenn die Dosis zwischen mehreren oder allen Segmenten übereinstimmt. Segmente mit Tagesabschnitten werden in der festen Reihenfolge morgens, mittags, abends, zur Nacht sortiert; Segmente mit Uhrzeiten anhand des Eingabestrings aufsteigend. Treten – bei nicht profilkonformem Input über mehrere `Dosage`-Elemente hinweg – beide Arten gemeinsam auf, stehen **alle** Tagesabschnitte vor **allen** Uhrzeiten. Die Segmente werden mit Komma getrennt. Bei mehrfacher Belegung desselben Zeit-Schlüssels verwendet der Algorithmus die Dosis des zuerst durchlaufenen zugehörigen `Dosage`-Elements; profilkonformer Input verhindert diesen Mehrdeutigkeitsfall.
+
+Der gemeinsame Einnahmerhythmus wird aus `period`, `periodMax` und `periodUnit`
+gebildet. Eine vorhandene `frequency` wird nicht ausgegeben, weil die Anzahl der
+Anwendungen bereits aus den aufgeführten `timeOfDay`- beziehungsweise
+`when`-Segmenten hervorgeht.
 
 *Beispiel:* `alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück`
 
@@ -411,14 +432,14 @@ Bei einer **reinen Bedarfsdosierung** muss die Ressource genau ein `Dosage`-Elem
 * Sofern vorhanden, steht der **Zeitrahmen** am Anfang, gefolgt vom **Einnahmeanlass** und einem **Doppelpunkt**. Der Doppelpunkt steht damit direkt hinter dem Einnahmeanlass.
 * Ist kein Einnahmeanlass angegeben, wird generisch `bei Bedarf` gesetzt.
 * Das **erste Zeichen der Zeile** wird großgeschrieben (`Bei Kopfschmerzen: …`, `Bei Bedarf: …`).
-* Ein optionaler **Mindestabstand** (`modifierExtension[MindestabstandZwischenGaben]`) und – bei strukturiertem Bedarf – das jeweilige Schema (Intervall, 4‑Schema …) folgen rechts des Doppelpunkts.
+* Ein optionaler **Mindestabstand** (`modifierExtension[MindestabstandZwischenGaben]`) und – bei strukturiertem Bedarf – das jeweilige Schema (Intervall, 4‑Schema …) folgen rechts des Doppelpunkts. Bei einer reinen Bedarfsdosierung steht der Mindestabstand vor der Dosis. Bei strukturiertem Bedarf steht er nach dem Schemakern als `, mit mindestens … Abstand`, damit beispielsweise `alle 8 Stunden` und `mindestens 6 Stunden Abstand` nicht unmittelbar und missverständlich aufeinanderfolgen.
   Die **Maximalmenge** wird genau einmal am Ende der Dosierungsanweisung angefügt. Enthält die Anweisung mehrere Uhrzeit-, Tagesabschnitts- oder Wochentagssegmente, steht die Maximalmenge nach dem letzten Segment. Sie gilt für die Gesamtmenge im angegebenen Zeitraum. Ein anschließender `Hinweis: ` folgt erst danach.
 
 *Beispiele:*
 
 * `Bei Kopfschmerzen: im Abstand von mindestens 4 Stunden je 1 Stück — nicht mehr als 6 Stück in 24 Stunden`
 * `Bei Bedarf: täglich 08:00 Uhr — je 1 Stück, 20:00 Uhr — je 2 Stück — nicht mehr als 6 Stück pro Tag`
-* `Bei Kopfschmerzen: alle 8 Stunden je 1 Stück`
+* `Bei Kopfschmerzen: alle 8 Stunden je 1 Stück, mit mindestens 6 Stunden Abstand — nicht mehr als 4 Stück in 24 Stunden`
 * `Bei Bedarf: 1-0-2-0 Stück`
 
 ### Freitext-Dosierung

--- a/input/pagecontent/schema-intervall-kombination.md
+++ b/input/pagecontent/schema-intervall-kombination.md
@@ -13,21 +13,22 @@ Folgende weitere Beispiele sind in diesem IG dargestellt:
 | Jeden 2. Tag 1 Stück um 08:00 Uhr und 2 Stück um 18:00 Uhr  | [Example-MR-Dosage-comb-interval-1](./MedicationRequest-Example-MR-Dosage-comb-interval-1.html)    |  |
 | 1 x pro Woche 1 Stück morgens  | [Example-MR-Dosage-comb-interval-2](./MedicationRequest-Example-MR-Dosage-comb-interval-2.html)    |
 | Jeden 2. Tag 1 Stück um 08:00 Uhr und jeden 2. Tag 1 Stück um 08:00 Uhr  | [Example-MR-Dosage-comb-interval-3](./MedicationRequest-Example-MR-Dosage-comb-interval-3.html)    |
+| Jeden 2. Tag 1 Stück um 08:00 und 20:00 Uhr sowie 2 Stück um 10:00, 14:00 und 22:00 Uhr (ohne `frequency`)  | [Example-MR-Dosage-comb-interval-4](./MedicationRequest-Example-MR-Dosage-comb-interval-4.html)    |
+| Dasselbe Schema mit zusätzlich angegebener, redundanter `frequency`  | [Example-MR-Dosage-comb-interval-5](./MedicationRequest-Example-MR-Dosage-comb-interval-5.html)    |
 
 ### Angabe und Erkennung der Dosierart 
 
 Diese Dosierungsart wird daran erkannt, dass folgende Felder unter `Dosage.timing.repeat` angegeben sind:
 
-- `frequency`
 - `period`
 - `periodUnit`
 - `timeOfDay` ODER `when`
+- opt. Angabe von `frequency`
 - opt. Angabe von `bounds[x]`
 
 Folgende FHIR-Path Expression auf Ebene von `Dosage.timing.repeat` liefert die Angabe, ob es sich um das Schema handelt:
 
 ```
-timing.repeat.frequency.exists() and
 timing.repeat.period.exists() and
 timing.repeat.periodUnit.exists() and
 timing.repeat.dayOfWeek.empty() and
@@ -37,9 +38,26 @@ timing.repeat.dayOfWeek.empty() and
   )
 ```
 
-Der Wert von frequency entspricht dabei der Anzahl an Elementen in `when`, bzw. `timeOfDay`.
+Wird `frequency` zusätzlich angegeben, entspricht der Wert der Anzahl an Elementen
+in `when` beziehungsweise `timeOfDay`. Die Angabe ist redundant und wird im
+generierten Dosierungstext nicht ausgegeben, weil sich die Häufigkeit bereits aus
+den konkreten Zeitpunkten ergibt.
+[Example-MR-Dosage-comb-interval-4](./MedicationRequest-Example-MR-Dosage-comb-interval-4.html)
+und [Example-MR-Dosage-comb-interval-5](./MedicationRequest-Example-MR-Dosage-comb-interval-5.html)
+bilden dasselbe Schema einmal ohne und einmal mit `frequency` ab und erzeugen
+denselben Dosierungstext.
 
-und entweder `when` oder `timeOfDay`. Damit kann diese Dosierangabe verwendet werden um eine Interval angabe auf Tageszeit oder Uhrzeit zu kombinieren.
+Die Warnung `TimingVarFreqOrPeriod`, die eine gleichzeitige Erhöhung von
+`frequency` und `period` beanstandet, gilt ausschließlich für reine
+Intervallangaben ohne Zeitpunkte. Im Kombinationsschema ist `frequency` die
+Anzahl der Zeitpunkte und kein Faktor des Einnahmerhythmus, deshalb greift die
+Warnung hier nicht.
+
+Mit `period` und `periodUnit` wird der Einnahmerhythmus festgelegt. `when` oder
+`timeOfDay` ordnet diesem Rhythmus konkrete Tagesabschnitte beziehungsweise
+Uhrzeiten zu.
 
 Lesende Systeme werten entsprechend auch `Dosage.timing.repeat` aus. 
-Wenn die oben genannten Felder angegeben sind, ist dem Nutzer anzuzeigen, dass die Dosierung nach einem Interval mit Tageszeit oder Uhrzeitbezug definiert ist.
+Wenn die oben genannten Felder angegeben sind, ist dem Nutzer anzuzeigen, dass die
+Dosierung nach einem Einnahmerhythmus mit Tageszeit- oder Uhrzeitbezug definiert
+ist.

--- a/scripts/medication-dosage-to-text.py
+++ b/scripts/medication-dosage-to-text.py
@@ -22,10 +22,10 @@ The script supports various dosage schemas:
 Algorithm Priority (TimingOnlyOneType constraint):
 1. FreeText (has text, no timing, no doseAndRate)
 2. AsNeeded (asNeededBoolean=true, no timing)
-3. 4-Schema ('when' codes, no timeOfDay/dayOfWeek)
+3. 4-Schema ('when' codes, no timeOfDay/dayOfWeek, and no period or exactly 1 d)
 4. DayOfWeek (has dayOfWeek, no when/timeOfDay)
 5. DayOfWeek + Time/4-Schema (has dayOfWeek + timeOfDay OR when)
-6. TimeOfDay (daily period with timeOfDay, no dayOfWeek/when)
+6. TimeOfDay (daily or no period with timeOfDay, no dayOfWeek/when)
 7. Interval + Time/4-Schema (non-daily period with timeOfDay OR when)
 8. Interval (pure interval without when/timeOfDay/dayOfWeek)
 
@@ -291,8 +291,11 @@ class MedicationDosageTextGenerator:
         is_pure_interval = (has_frequency and has_period and has_period_unit and
                             not has_when_codes and not has_time_of_day and not has_day_of_week)
 
-        # Schema 3: 4-Schema - 'when' codes only (frequency/period optional)
-        if (has_when_codes and not has_time_of_day and not has_day_of_week):
+        # Schema 3: 4-Schema - 'when' codes without a non-daily period.
+        # frequency is optional and does not affect schema selection. A non-daily
+        # period together with when belongs to the interval combination schema.
+        if (has_when_codes and not has_time_of_day and not has_day_of_week and
+                (is_daily_pattern or (not has_period and not has_period_unit))):
             return self.SCHEMA_4_PATTERN
 
         # Schema 4: DayOfWeek - specific weekdays, no timing details
@@ -306,7 +309,7 @@ class MedicationDosageTextGenerator:
         # Schema 6: TimeOfDay - specific times only. If no period is specified,
         # the time-of-day pattern is still interpreted as a daily schedule.
         if (has_time_of_day and not has_day_of_week and not has_when_codes and
-                (is_daily_pattern or (not has_frequency and not has_period and not has_period_unit))):
+                (is_daily_pattern or (not has_period and not has_period_unit))):
             return self.SCHEMA_TIME_OF_DAY
 
         # Schema 7: Interval + Time/4-Schema - non-daily period with timing
@@ -666,9 +669,14 @@ class MedicationDosageTextGenerator:
         Nicht-Bedarf: [{Zeitrahmen} ][{middle}]: {core}
           - der Doppelpunkt trennt Zeitrahmen/Intervall (links) von der Dosis (rechts).
 
-        Bedarf: [{Zeitrahmen} ]bei {Einnahmeanlass}: [{Mindestabstand} ][{middle} ]{core}
-          - der Doppelpunkt steht direkt hinter dem Einnahmeanlass; Mindestabstand,
-            Intervall/Marker und Kern folgen rechts ohne weiteren Doppelpunkt.
+        Bedarf ohne strukturierten Rhythmus:
+          [{Zeitrahmen} ]bei {Einnahmeanlass}: [{Mindestabstand} ]{core}
+        Bedarf mit strukturiertem Rhythmus:
+          [{Zeitrahmen} ]bei {Einnahmeanlass}: {middle} {core}
+          [, mit mindestens {Mindestabstand} Abstand]
+          - der Doppelpunkt steht direkt hinter dem Einnahmeanlass.
+          - bei einem strukturierten Rhythmus wird der Mindestabstand nachgestellt,
+            damit Rhythmus und Mindestabstand sprachlich klar getrennt sind.
         """
         bounds_text = self._extract_bounds_text(dosage)
 
@@ -678,15 +686,17 @@ class MedicationDosageTextGenerator:
             anlass = f"bei {reason_text}" if reason_text else "bei Bedarf"
             left = " ".join(part for part in [bounds_text, anlass] if part)
 
-            right_parts = []
             minimum_interval = self._extract_minimum_interval_text(dosage)
-            if minimum_interval:
+            right_parts = []
+            if minimum_interval and not middle:
                 right_parts.append(f"im Abstand von mindestens {minimum_interval}")
             if middle:
                 right_parts.append(middle)
             if core:
                 right_parts.append(core)
             right = " ".join(right_parts)
+            if minimum_interval and middle:
+                right = f"{right}, mit mindestens {minimum_interval} Abstand"
             return f"{left}: {right}" if right else left
 
         # Nicht-Bedarf: Zeitrahmen und Intervall/Marker links, Kern rechts.
@@ -1006,6 +1016,13 @@ class MedicationDosageTextGenerator:
             else:
                 return f"{self._format_range_value(frequency, frequency_max)} x wöchentlich"
 
+        # Monthly patterns (periodUnit='mo', period=1)
+        if period_unit == 'mo' and period == 1:
+            if frequency == 1 and frequency_max is None:
+                return "monatlich"
+            else:
+                return f"{self._format_range_value(frequency, frequency_max)} x monatlich"
+
         # Kurzform nur für eine feste Frequenz von genau 1.
         if frequency == 1 and frequency_max is None:
             period_description = self._format_period_description(period, period_unit, period_max)
@@ -1031,6 +1048,17 @@ class MedicationDosageTextGenerator:
         unit_basis = period_max if period_max is not None else period
         unit_name = self._format_time_unit_german(unit_basis, period_unit)
         return f"{formatted_period} {unit_name}"
+
+    def _format_period_only_rhythm(self, period, period_unit, period_max=None):
+        """Formatiert einen Einnahmerhythmus ohne Frequenzangabe."""
+        if period_max is None and period == 1:
+            if period_unit == 'd':
+                return "täglich"
+            if period_unit == 'wk':
+                return "wöchentlich"
+            if period_unit == 'mo':
+                return "monatlich"
+        return f"alle {self._format_period_description(period, period_unit, period_max)}"
 
     def _format_range_value(self, value, max_value=None):
         formatted_value = self._format_decimal_value(value)
@@ -1196,7 +1224,7 @@ class MedicationDosageTextGenerator:
             str: Formatted text like "alle 2 Tage: 08:00 Uhr — je 1 Stück, 18:00 Uhr — je 2 Stück"
 
         Example FHIR input:
-            - timing.repeat.frequency = 1, period = 2, periodUnit = "d"
+            - timing.repeat.period = 2, periodUnit = "d"
             - timing.repeat.timeOfDay = ["08:00", "18:00"]
             - doseQuantity = {value: 1, unit: "Stück"}
 
@@ -1205,12 +1233,24 @@ class MedicationDosageTextGenerator:
         if not dosage_instructions:
             return ""
 
-        # Extract interval information from first dosage
+        # Extract the shared non-daily period from the first dosage. In an
+        # interval combination, explicit timeOfDay/when segments already state
+        # how often the dose is administered. An optional frequency is therefore
+        # deliberately not included in the common text prefix.
         first_dosage = dosage_instructions[0]
         timing = first_dosage.get('timing', {})
         repeat_element = timing.get('repeat', {})
 
-        interval_text = self._generate_frequency_description(first_dosage)
+        period = repeat_element.get('period')
+        period_max = repeat_element.get('periodMax')
+        period_unit = repeat_element.get('periodUnit')
+        if period is None or period_unit is None:
+            raise ValueError(
+                "Intervall-Kombinationen erfordern period und periodUnit."
+            )
+        interval_text = self._format_period_only_rhythm(
+            period, period_unit, period_max
+        )
 
         # Group dosages by time or when code
         time_to_dosages = {}  # time_key -> list of dosages
@@ -1279,10 +1319,11 @@ class MedicationDosageTextGenerator:
         {Mindestabstand} ]je {Dosis}[ — nicht mehr als {Maximalmenge} {Zeitraum}]
         ({Zeitraum} = "in 24 Stunden" bei 24 h bzw. "pro Tag" bei 1 d)
 
-        Der Doppelpunkt hinter dem Einnahmeanlass, Zeitrahmen und Mindestabstand
-        werden von _assemble gesetzt; die Maximalmenge und der Großbuchstabe am
-        Zeilenanfang werden zentral ergänzt (_append_trailing_instructions /
-        _finalize_text).
+        Bei strukturiertem Bedarf wird der Mindestabstand stattdessen nach dem
+        Schema-Kern als ", mit mindestens ... Abstand" ausgegeben. Der Doppelpunkt
+        hinter dem Einnahmeanlass, Zeitrahmen und Mindestabstand werden von
+        _assemble gesetzt; die Maximalmenge und der Großbuchstabe am Zeilenanfang
+        werden zentral ergänzt (_append_trailing_instructions / _finalize_text).
         """
         if not dosage_instructions:
             return ""

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: MedicationDE
 title: Medication IG DE
 # description: Example Implementation Guide for getting started with SUSHI
 status: active # draft | active | retired | unknown
-version: 1.1.0
+version: 2.0.0-alpha1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
 releaseLabel: STU1


### PR DESCRIPTION
This pull request makes several important updates to the dosage timing logic, examples, and documentation to clarify and improve handling of interval and combination schedules in medication dosage schemas. The main focus is on refining the rules for how `frequency`, `period`, and related fields interact—especially in cases where both are present—and on updating examples and documentation to ensure consistency and clarity.

**Dosage Timing Logic and Validation:**

* The invariant `TimingVarFreqOrPeriod` in `TimingDgMP.fsh` is refined to only apply when no time points (`timeOfDay`, `when`, `dayOfWeek`) are present, clarifying that the rule about not varying both frequency and period only applies to pure interval schedules. The description and logic are updated accordingly. [[1]](diffhunk://#diff-17facd63336d466334353eb0f1021bce2ac2ae19d2b61d21253a62314fafadd3L188-R196) [[2]](diffhunk://#diff-4bbdcc34f30d260fdc5d2ad38413261344db86bd9dc77c746a54b381bcd7e144L144-R147)
* The interval/time schema detection logic is simplified by removing an unnecessary check for `timing.repeat.frequency.exists()` when validating the presence of period and periodUnit.

**Examples and Test Data:**

* Several example instances in `scheme_examples_comb_interval.fsh` are updated or added to better illustrate interval combinations, including a new example (`Example-MR-Dosage-comb-interval-5`) that demonstrates redundant frequency specification. Descriptions and period units are corrected for accuracy. [[1]](diffhunk://#diff-6996d6ef57165b93b6ae067bb5bedcf6bf9e8690192620720a84ca94f9dc2917L38-R38) [[2]](diffhunk://#diff-6996d6ef57165b93b6ae067bb5bedcf6bf9e8690192620720a84ca94f9dc2917L70-R95)
* Example `Example-MR-Dosage-1010-10-Days` in `scheme_examples_when.fsh` is corrected to use 10 days instead of 10 weeks, updating both the title, description, and duration unit. [[1]](diffhunk://#diff-79cff8c282ca7e8f7a3a051d195cfcfe09982440464ddc244ec5a0099d81073cL124-R125) [[2]](diffhunk://#diff-79cff8c282ca7e8f7a3a051d195cfcfe09982440464ddc244ec5a0099d81073cL134-R134)

**Documentation and Summary Matrix:**

* The dosage summary matrix (`dosage-summary-matrix.md`) is updated with clearer and more precise descriptions for interval and combination schedules, reflecting the improved logic and terminology. New examples are added and existing ones are corrected for consistency. [[1]](diffhunk://#diff-68075eea0965b06413be1c999fc5b7c41b49f76f5f92d3a28df950dbf6b68641L23-R23) [[2]](diffhunk://#diff-68075eea0965b06413be1c999fc5b7c41b49f76f5f92d3a28df950dbf6b68641L35-R43) [[3]](diffhunk://#diff-68075eea0965b06413be1c999fc5b7c41b49f76f5f92d3a28df950dbf6b68641L60-R60) [[4]](diffhunk://#diff-68075eea0965b06413be1c999fc5b7c41b49f76f5f92d3a28df950dbf6b68641L73-R80) [[5]](diffhunk://#diff-68075eea0965b06413be1c999fc5b7c41b49f76f5f92d3a28df950dbf6b68641L110-R112) [[6]](diffhunk://#diff-68075eea0965b06413be1c999fc5b7c41b49f76f5f92d3a28df950dbf6b68641L139-R141)
* The documentation for dosage text generation is expanded to clarify how interval and combination schedules are rendered, including when frequency is omitted and how period units are verbalized. The rules for when each field is required are also made more explicit.

These changes improve the accuracy, clarity, and maintainability of dosage timing logic and its documentation, ensuring that both implementers and end users have a consistent understanding of how complex dosage schedules are represented and validated.